### PR TITLE
Fix missing / in markdown code for badge

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -367,5 +367,5 @@ https://api.cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>.svg?branch=
 Here is how Cirrus CI's badge can be embeded in a Markdown file:
 
 ```markdown
-[![Build Status](https://api.cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>.svg)](https://cirrus-ci.com/github<USER OR ORGANIZATION>/<REPOSITORY>)
+[![Build Status](https://api.cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>.svg)](https://cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>)
 ```


### PR DESCRIPTION
Hi :wave: 

I just started integrating cirrus and notice that there is a small typo in the markdown button copy paste code. It seems to be missing a `/`.

Thank you for Cirrus! It's awesome :tada: 