### PR TITLE
Update language, and syntax for timeout_in feature

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,12 +42,12 @@ and then contact [support](/support.md) if it's still not clear what happened.
 
 #### Instance timed out!
 
-By default Cirrus CI has an execution limit of 60 minutes for each task. Therefore, this default timeout duration can be changed
+By default Cirrus CI has an execution limit of 60 minutes for each task. However, this default timeout duration can be changed
 by using `timeout_in` field in `.cirrus.yml` configuration file:
 
 ```yaml
 task: 
-  timeout_in 90m
+  timeout_in: 90m
   ...
 ```
 


### PR DESCRIPTION
Seems like it's missing a colon. (and "However" is more correct than "Therefore" in the preceding sentence).