### PR TITLE
Update Bazel example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -67,9 +67,9 @@ container:
 task:
   build_script: |
     bazel build \
-      --spawn_strategy=remote_http_cache \
-      --strategy=Javac=remote_http_cache \
-      --genrule_strategy=remote_http_cache \
+      --spawn_strategy=remote \
+      --strategy=Javac=remote \
+      --genrule_strategy=remote \
       --remote_rest_cache=http://$CIRRUS_HTTP_CACHE_HOST \
       //...
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -67,10 +67,10 @@ container:
 task:
   build_script: |
     bazel build \
-      --spawn_strategy=remote \
-      --strategy=Javac=remote \
-      --genrule_strategy=remote \
-      --remote_rest_cache=http://$CIRRUS_HTTP_CACHE_HOST \
+      --spawn_strategy=sandboxed \
+      --strategy=Javac=sandboxed \
+      --genrule_strategy=sandboxed \
+      --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST \
       //...
 ```
 


### PR DESCRIPTION
- Revert commit 6961ac1ad7672bc84b6134310b63bab62434740e which misunderstood the fix
- Update `--remote_rest_cache` to `remote_http_cache` as per [release note 0.10.0][release-0100]
  > --remote_rest_cache was renamed to --remote_http_cache. Both options keep working in this release, but --remote_rest_cache will be removed in the next release.
- Update `--*strategy=remote` to `standalone` as per [remote caching][remote-caching]

[release-0100]: https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-0100-2018-02-01
[remote-caching]: https://docs.bazel.build/versions/master/remote-caching.html#read-from-and-write-to-the-remote-cache

Fix #61 