### PR TITLE
Add markdown tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,8 @@ build_task:
   build_script: mkdocs build
 
 deploy_task:
+  container:
+    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH == 'master'
   depends_on:
     - build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ Deploy_task:
 
 # ====== MARKDOWN TESTS ======
 task:
-  allow_failures: true
+  skip_notifications: true
   name: Markdown_Lint
   container:
     image: mivok/markdownlint:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,37 +2,39 @@ container:
   image: squidfunk/mkdocs-material:latest
 
 # ====== MKDOCS TEST ======
-build_task:
+Build_task:
   only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
   install_script: pip install --upgrade pymdown-extensions
   build_script: mkdocs build
 
 # ====== MKDOCS DEPLOY ======
-deploy_task:
+Deploy_task:
   only_if: $CIRRUS_BRANCH == 'master'
   container:
     image: python:latest
   depends_on:
-    - build
-    - markdown_lint
-    - markdown_linkcheck
+    - Build
+    - Markdown_Lint
+    - Markdown_LinkCheck
   env:
     DEPLOY_TOKEN: ENCRYPTED[fbf2f9b7dc97cc3d960126b1540f19c36b96768c46b8eb99389e02b8c54080418d1fb90094dc2e3a36767df34acb5d5d]
   install_script: pip install pymdown-extensions
   deploy_script: ./.ci/deploy.sh
 
 # ====== MARKDOWN TESTS ======
-markdown_lint_task:
+task:
+  name: Markdown_Lint
   container:
     image: mivok/markdownlint:latest
   script: 
     - echo ========  STARTING MARKDOWN LINTING TESTS  ========
     - mdl docs/
 
-markdown_linkcheck_task:
+task:
+  name: Markdown_LinkCheck
   container:
     image: node:latest
-  install_script:
+  Install_script:
     - npm install -g markdown-link-check@3.7.2
   script:
     - echo ========  STARTING MARKDOWN LINK CHECK TESTS  ========

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,12 +24,10 @@ deploy_task:
 # ====== MARKDOWN TESTS ======
 markdown_lint_task:
   container:
-    image: node:latest
-  install_script:
-    - npm install -g remark-lint remark-cli
+    image: mivok/markdownlint:latest
   script: 
     - echo ========  STARTING MARKDOWN LINTING TESTS  ========
-    - find . -name \*.md -exec remark {} \;
+    - mdl docs/
 
 markdown_linkcheck_task:
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ Deploy_task:
 
 # ====== MARKDOWN TESTS ======
 task:
-  allow_failures: $CI != false
+  allow_failures: true
   name: Markdown_Lint
   container:
     image: mivok/markdownlint:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,12 @@
-container:
-  image: squidfunk/mkdocs-material:latest
-  cpu: 2
-
+# ====== MKDOCS TEST ======
 build_task:
+  container:
+    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
   install_script: pip install --upgrade pymdown-extensions
   build_script: mkdocs build
 
+# ====== MKDOCS DEPLOY ======
 deploy_task:
   only_if: $CIRRUS_BRANCH == 'master'
   container:
@@ -20,6 +20,7 @@ deploy_task:
   install_script: pip install pymdown-extensions
   deploy_script: ./.ci/deploy.sh
 
+# ====== MARKDOWN TESTS ======
 markdown_lint_task:
   container:
     image: node:latest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,5 @@
 container:
   image: squidfunk/mkdocs-material:latest
-  image: node:latest
-  image: python:latest
   cpu: 2
 
 build_task:
@@ -11,6 +9,8 @@ build_task:
 
 deploy_task:
   only_if: $CIRRUS_BRANCH == 'master'
+  container:
+    image: python:latest
   depends_on:
     - build
     - markdown_lint
@@ -21,6 +21,8 @@ deploy_task:
   deploy_script: ./.ci/deploy.sh
 
 markdown_lint_task:
+  container:
+    image: node:latest
   install_script:
     - npm install -g remark-lint remark-cli
   script: 
@@ -28,6 +30,8 @@ markdown_lint_task:
     - find . -name \*.md -exec remark {} \;
 
 markdown_linkcheck_task:
+  container:
+    image: node:latest
   install_script:
     - npm install -g markdown-link-check@3.7.2
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,3 +12,15 @@ deploy_task:
     DEPLOY_TOKEN: ENCRYPTED[fbf2f9b7dc97cc3d960126b1540f19c36b96768c46b8eb99389e02b8c54080418d1fb90094dc2e3a36767df34acb5d5d]
   install_script: pip install pymdown-extensions
   deploy_script: ./.ci/deploy.sh
+
+markdown_tests_task:
+  container:
+    image: node:latest
+  depends_on:
+    - build
+  node_modules_cache:
+    folder: node_modules
+    populate_script: npm install -g remark-lint remark-cli remark-preset-lint-recommended && npm install -g markdown-link-check@3.7.2
+  script: 
+    - find . -name \*.md -exec remark {} \;
+    - find . -name \*.md -exec markdown-link-check {} \;

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 container:
   image: squidfunk/mkdocs-material:latest
   image: node:latest
+  image: python:latest
   cpu: 2
 
 build_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ Deploy_task:
     image: python:latest
   depends_on:
     - Build
-    - Markdown_Lint
+#    - Markdown_Lint
     - Markdown_LinkCheck
   env:
     DEPLOY_TOKEN: ENCRYPTED[fbf2f9b7dc97cc3d960126b1540f19c36b96768c46b8eb99389e02b8c54080418d1fb90094dc2e3a36767df34acb5d5d]
@@ -22,13 +22,13 @@ Deploy_task:
   deploy_script: ./.ci/deploy.sh
 
 # ====== MARKDOWN TESTS ======
-task:
-  skip_notifications: true
-  name: Markdown_Lint
-  container:
-    image: mivok/markdownlint:latest
-  script: 
-    - mdl docs/
+#task:
+#  skip_notifications: true
+#  name: Markdown_Lint
+#  container:
+#    image: mivok/markdownlint:latest
+#  script: 
+#    - mdl docs/
 
 task:
   name: Markdown_LinkCheck

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,6 @@ task:
   container:
     image: mivok/markdownlint:latest
   script: 
-    - echo ========  STARTING MARKDOWN LINTING TESTS  ========
     - mdl docs/
 
 task:
@@ -37,5 +36,4 @@ task:
   Install_script:
     - npm install -g markdown-link-check@3.7.2
   script:
-    - echo ========  STARTING MARKDOWN LINK CHECK TESTS  ========
     - find . -name \*.md -exec markdown-link-check {} \;

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,8 @@
+container:
+  image: squidfunk/mkdocs-material:latest
+
 # ====== MKDOCS TEST ======
 build_task:
-  container:
-    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
   install_script: pip install --upgrade pymdown-extensions
   build_script: mkdocs build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,5 +22,7 @@ markdown_tests_task:
     folder: node_modules
     populate_script: npm install -g remark-lint remark-cli remark-preset-lint-recommended && npm install -g markdown-link-check@3.7.2
   script: 
+    - echo ========  STARTING MARKDOWN LINTING TESTS  ========
     - find . -name \*.md -exec remark {} \;
+    - echo ========  STARTING MARKDOWN LINK CHECK TESTS  ========
     - find . -name \*.md -exec markdown-link-check {} \;

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,13 +1,14 @@
+container:
+  image: squidfunk/mkdocs-material:latest
+  image: node:latest
+  cpu: 2
+
 build_task:
-  container:
-    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
   install_script: pip install --upgrade pymdown-extensions
   build_script: mkdocs build
 
 deploy_task:
-  container:
-    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH == 'master'
   depends_on:
     - build
@@ -19,15 +20,13 @@ deploy_task:
   deploy_script: ./.ci/deploy.sh
 
 markdown_lint_task:
-  install_script: 
+  install_script:
     - npm install -g remark-lint remark-cli
   script: 
     - echo ========  STARTING MARKDOWN LINTING TESTS  ========
     - find . -name \*.md -exec remark {} \;
 
 markdown_linkcheck_task:
-  container:
-    image: node:latest
   install_script:
     - npm install -g markdown-link-check@3.7.2
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,28 +1,33 @@
-container:
-  image: squidfunk/mkdocs-material:latest
-
 build_task:
+  container:
+    image: squidfunk/mkdocs-material:latest
   only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
   install_script: pip install --upgrade pymdown-extensions
   build_script: mkdocs build
 
 deploy_task:
   only_if: $CIRRUS_BRANCH == 'master'
+  depends_on:
+    - build
+    - markdown_lint
+    - markdown_linkcheck
   env:
     DEPLOY_TOKEN: ENCRYPTED[fbf2f9b7dc97cc3d960126b1540f19c36b96768c46b8eb99389e02b8c54080418d1fb90094dc2e3a36767df34acb5d5d]
   install_script: pip install pymdown-extensions
   deploy_script: ./.ci/deploy.sh
 
-markdown_tests_task:
-  container:
-    image: node:latest
-  depends_on:
-    - build
-  node_modules_cache:
-    folder: node_modules
-    populate_script: npm install -g remark-lint remark-cli remark-preset-lint-recommended && npm install -g markdown-link-check@3.7.2
+markdown_lint_task:
+  install_script: 
+    - npm install -g remark-lint remark-cli
   script: 
     - echo ========  STARTING MARKDOWN LINTING TESTS  ========
     - find . -name \*.md -exec remark {} \;
+
+markdown_linkcheck_task:
+  container:
+    image: node:latest
+  install_script:
+    - npm install -g markdown-link-check@3.7.2
+  script:
     - echo ========  STARTING MARKDOWN LINK CHECK TESTS  ========
     - find . -name \*.md -exec markdown-link-check {} \;

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,7 @@ Deploy_task:
 
 # ====== MARKDOWN TESTS ======
 task:
+  allow_failures: $CI != false
   name: Markdown_Lint
   container:
     image: mivok/markdownlint:latest

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,7 +38,8 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
 
 !!! note "No per repository limits"
     Cirrus CI doesn't enforce any limits on repository or organization levels. All the limits are on per user basis.
-    For example, if you have 10 active contributors to a repository then you can end up with 130 tasks running in parallel 
+    For example, if you have 10 active contributors to a
+    repository then you can end up with 130 tasks running in parallel
     for the repository.  
 
 #### CI agent stopped responding
@@ -46,10 +47,13 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
 It means that Cirrus CI haven't heard from the agent for quite some time. In 99.999% of the cases 
 it happens because of two reasons:
 
-1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster). Community Cluster 
-is backed by Google Cloud's [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
-Google Cloud preempted back a VM your task was executing on. Cirrus CI is trying to minimize possibility of such cases 
-by constantly rotating VMs before Google Cloud preempts them, but there is still chance of such inconvenience.
+1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster).
+Community Cluster is backed by Google Cloud's 
+[Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
+Google Cloud preempted back a VM your task was executing on.
+Cirrus CI is trying to minimize possibility of such cases 
+by constantly rotating VMs before Google Cloud preempts them,
+but there is still chance of such inconvenience.
 
 2. Your CI task used too much memory which led to a crash of a VM or a container.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,10 +30,10 @@ either private or public repositories.
 Cirrus CI has following limitations on how many VMs or 
 Containers a single user can run for free for public repositories:
 
-  * 8 Linux Containers or VMs
-  * 2 Windows Containers or VMs
-  * 2 FreeBSD VMs
-  * 1 macOS VM
+- 8 Linux Containers or VMs
+- 2 Windows Containers or VMs
+- 2 FreeBSD VMs
+- 1 macOS VM
   
 Which means that a single user can run at most 13 simultaneous tasks for free.
 
@@ -50,13 +50,12 @@ It means that Cirrus CI haven't heard from the agent for quite some time. In 99.
 it happens because of two reasons:
 
 1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster).
-Community Cluster is backed by Google Cloud's 
-[Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
-Google Cloud preempted back a VM your task was executing on.
-Cirrus CI is trying to minimize possibility of such cases 
-by constantly rotating VMs before Google Cloud preempts them,
-but there is still chance of such inconvenience.
-
+   Community Cluster is backed by Google Cloud's 
+   [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
+   Google Cloud preempted back a VM your task was executing on.
+   Cirrus CI is trying to minimize possibility of such cases 
+   by constantly rotating VMs before Google Cloud preempts them,
+   but there is still chance of such inconvenience.
 2. Your CI task used too much memory which led to a crash of a VM or a container.
 
 #### Instance failed to start

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-#### Is Cirrus CI a delivery platform?
+#### Is Cirrus CI a delivery platform
 
 Cirrus CI is not positioned as a delivery platform but can be used as one for many general use cases by having 
 [Dependencies](guide/writing-tasks.md#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks.md#conditional-task-execution):
@@ -20,10 +20,12 @@ publish_task:
   script: yarn run publish
 ```
 
-#### Are there any limits?
+#### Are there any limits
 
-There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](/guide/supported-computing-services.md)
-or use [Compute Credits](/pricing.md#compute-credits) for either private or public repositories.
+There are no limits on how many VMs or Containers you can run in parallel 
+if you bring your own [compute services](/guide/supported-computing-services.md)
+or use [Compute Credits](/pricing.md#compute-credits) for 
+either private or public repositories.
 
 Cirrus CI has following limitations on how many VMs or Containers a single user can run for free for public repositories:
 
@@ -39,7 +41,7 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
     For example, if you have 10 active contributors to a repository then you can end up with 130 tasks running in parallel 
     for the repository.  
 
-#### CI agent stopped responding!
+#### CI agent stopped responding
 
 It means that Cirrus CI haven't heard from the agent for quite some time. In 99.999% of the cases 
 it happens because of two reasons:
@@ -51,7 +53,7 @@ by constantly rotating VMs before Google Cloud preempts them, but there is still
 
 2. Your CI task used too much memory which led to a crash of a VM or a container.
 
-#### Instance failed to start!
+#### Instance failed to start
 
 It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services.md) 
 to allocate resources. But a requested resource wasn't created. 
@@ -59,7 +61,7 @@ to allocate resources. But a requested resource wasn't created.
 If it happened for an OSS project, please contact [support](/support.md) immediately. Otherwise check your cloud console first 
 and then contact [support](/support.md) if it's still not clear what happened. 
 
-#### Instance got rescheduled!
+#### Instance got rescheduled
 
 Cirrus CI is trying to be as efficient as possible and uses an auto-scalable cluster of [preemptible VMs](https://cloud.google.com/preemptible-vms/)
 to run [Linux containers for OSS](/guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
@@ -71,7 +73,7 @@ This is a rare event since autoscaler is constantly rotating instances but preem
 !!! tip "Compute Credits"
     Tasks that use [compute credits](/pricing.md#compute-credits) are executed on standard VMs that don't get preempted.    
 
-#### Instance timed out!
+#### Instance timed out
 
 By default Cirrus CI has an execution limit of 60 minutes for each task. However, this default timeout duration can be changed
 by using `timeout_in` field in `.cirrus.yml` configuration file:
@@ -82,12 +84,12 @@ task:
   ...
 ```
 
-#### Only GitHub Support?
+#### Only GitHub Support
 
 At the moment Cirrus CI only supports GitHub via a [GitHub Application](https://github.com/apps/cirrus-ci). We are planning
 to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) next. 
 
-#### Any discounts?
+#### Any discounts
 
 Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services.md#community-cluster) 
 which is free for open source projects. But since Cirrus CI delegates execution of builds to different computing services,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,8 @@ if you bring your own [compute services](/guide/supported-computing-services.md)
 or use [Compute Credits](/pricing.md#compute-credits) for 
 either private or public repositories.
 
-Cirrus CI has following limitations on how many VMs or Containers a single user can run for free for public repositories:
+Cirrus CI has following limitations on how many VMs or 
+Containers a single user can run for free for public repositories:
 
   * 8 Linux Containers or VMs
   * 2 Windows Containers or VMs
@@ -37,7 +38,8 @@ Cirrus CI has following limitations on how many VMs or Containers a single user 
 Which means that a single user can run at most 13 simultaneous tasks for free.
 
 !!! note "No per repository limits"
-    Cirrus CI doesn't enforce any limits on repository or organization levels. All the limits are on per user basis.
+    Cirrus CI doesn't enforce any limits on repository or 
+    organization levels. All the limits are on per user basis.
     For example, if you have 10 active contributors to a
     repository then you can end up with 130 tasks running in parallel
     for the repository.  
@@ -62,7 +64,8 @@ but there is still chance of such inconvenience.
 It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services.md) 
 to allocate resources. But a requested resource wasn't created. 
 
-If it happened for an OSS project, please contact [support](/support.md) immediately. Otherwise check your cloud console first 
+If it happened for an OSS project, please contact [support](/support.md) immediately.
+Otherwise check your cloud console first
 and then contact [support](/support.md) if it's still not clear what happened.
 
 #### Instance got rescheduled
@@ -79,7 +82,8 @@ This is a rare event since autoscaler is constantly rotating instances but preem
 
 #### Instance timed out
 
-By default Cirrus CI has an execution limit of 60 minutes for each task. However, this default timeout duration can be changed
+By default Cirrus CI has an execution limit of 60 minutes for each task. However,
+this default timeout duration can be changed
 by using `timeout_in` field in `.cirrus.yml` configuration file:
 
 ```yaml
@@ -90,7 +94,8 @@ task:
 
 #### Only GitHub Support
 
-At the moment Cirrus CI only supports GitHub via a [GitHub Application](https://github.com/apps/cirrus-ci). We are planning
+At the moment Cirrus CI only supports GitHub via a 
+[GitHub Application](https://github.com/apps/cirrus-ci). We are planning
 to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) next.
 
 #### Any discounts

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,13 +59,13 @@ It means that Cirrus CI have made a successful API call to a [computing service]
 to allocate resources. But a requested resource wasn't created. 
 
 If it happened for an OSS project, please contact [support](/support.md) immediately. Otherwise check your cloud console first 
-and then contact [support](/support.md) if it's still not clear what happened. 
+and then contact [support](/support.md) if it's still not clear what happened.
 
 #### Instance got rescheduled
 
 Cirrus CI is trying to be as efficient as possible and uses an auto-scalable cluster of [preemptible VMs](https://cloud.google.com/preemptible-vms/)
-to run [Linux containers for OSS](/guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
-that **run tasks for OSS projects free of charge** but it comes with a rare edge case... 
+to run [Linux containers for OSS](/guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure
+that **run tasks for OSS projects free of charge** but it comes with a rare edge case...
 
 Preemptible VMs can be preempted which will require to reschedule and automatically restart tasks that were executing on these VMs. 
 This is a rare event since autoscaler is constantly rotating instances but preemption still happens occasionally.
@@ -79,7 +79,7 @@ By default Cirrus CI has an execution limit of 60 minutes for each task. However
 by using `timeout_in` field in `.cirrus.yml` configuration file:
 
 ```yaml
-task: 
+task:
   timeout_in: 90m
   ...
 ```
@@ -87,10 +87,12 @@ task:
 #### Only GitHub Support
 
 At the moment Cirrus CI only supports GitHub via a [GitHub Application](https://github.com/apps/cirrus-ci). We are planning
-to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) next. 
+to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) next.
 
 #### Any discounts
 
-Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services.md#community-cluster) 
-which is free for open source projects. But since Cirrus CI delegates execution of builds to different computing services,
+Cirrus CI itself doesn't provide any discounts except 
+[Community Cluster](/guide/supported-computing-services.md#community-cluster)
+which is free for open source projects. But since Cirrus CI 
+delegates execution of builds to different computing services,
 it means that discounts from your cloud provider will be applied to Cirrus CI builds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ patterns from Cirrus CI customers:
       </a>
     </td>
     <td>
-      [SonarSource](https://www.sonarsource.com/) is using [integration with Google Cloud Platform](/guide/supported-computing-services/)
+      <a href="https://www.sonarsource.com/">SonarSource</a> is using <a href="/guide/supported-computing-services/">integration with Google Cloud Platform</a>
       to bring their own infrastructure to Cirrus CI. SonarSource runs their integration tests in parallel on more than 
       a hundred dedicated VMs to get test results in minutes rather than hours.
     </td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ patterns from Cirrus CI customers:
       </a>
     </td>
     <td>
-      <a href="https://www.sonarsource.com/">SonarSource</a> is using <a href="/guide/supported-computing-services/">integration with Google Cloud Platform</a>
+      [SonarSource](https://www.sonarsource.com/) is using [integration with Google Cloud Platform](/guide/supported-computing-services/)
       to bring their own infrastructure to Cirrus CI. SonarSource runs their integration tests in parallel on more than 
       a hundred dedicated VMs to get test results in minutes rather than hours.
     </td>


### PR DESCRIPTION
This makes use of the `markdown-link-check` and `remark-lint` command line tools.  The first one checks for dead links, the second lints markdown files to see if they have any common problems.  