### PR TITLE
Configure linting

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,25 @@
-container:
-  image: squidfunk/mkdocs-material:latest
-
-build_task:
-  only_if: $CIRRUS_BRANCH != 'gh-pages' && $CIRRUS_BRANCH != 'master'
-  install_script: pip install --upgrade pymdown-extensions
-  build_script: mkdocs build
+task:
+  only_if: $CIRRUS_BRANCH != 'gh-pages'
+  matrix:
+    - name: build
+      container:
+        image: squidfunk/mkdocs-material:latest
+      install_script: pip install --upgrade pymdown-extensions
+      build_script: mkdocs build
+    - name: lint
+      container:
+        image: node:latest
+      install_script: npm install -g markdownlint-cli
+      lint_script: markdownlint --config=.markdownlint.yml docs/
 
 deploy_task:
   only_if: $CIRRUS_BRANCH == 'master'
+  depends_on:
+    - build
+    - lint
+  container:
+    image: squidfunk/mkdocs-material:latest
   env:
     DEPLOY_TOKEN: ENCRYPTED[fbf2f9b7dc97cc3d960126b1540f19c36b96768c46b8eb99389e02b8c54080418d1fb90094dc2e3a36767df34acb5d5d]
-  install_script: pip install pymdown-extensions
+  install_script: pip install --upgrade pymdown-extensions
   deploy_script: ./.ci/deploy.sh

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,10 @@
+"default": true
+"MD002": false # First heading should be a top level heading
+"MD007": # Unordered list indentation
+  indent: 4
+"MD009": false # Trailing spaces
+"MD013": false # Line length
+"MD025": false # Multiple top level headings in the same document
+"MD026": false # Trailing punctuation in heading
+"MD033": false # Inline HTML
+"MD041": false # Inline HTML

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -7,4 +7,4 @@
 "MD025": false # Multiple top level headings in the same document
 "MD026": false # Trailing punctuation in heading
 "MD033": false # Inline HTML
-"MD041": false # Inline HTML
+"MD041": false # First line in file should be a top level heading

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-#### Is Cirrus CI a delivery platform?
+## Is Cirrus CI a delivery platform?
 
 Cirrus CI is not positioned as a delivery platform but can be used as one for many general use cases by having 
 [Dependencies](guide/writing-tasks.md#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks.md#conditional-task-execution):
@@ -20,17 +20,17 @@ publish_task:
   script: yarn run publish
 ```
 
-#### Are there any limits?
+## Are there any limits?
 
 There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](/guide/supported-computing-services.md)
 or use [Compute Credits](/pricing.md#compute-credits) for either private or public repositories.
 
 Cirrus CI has following limitations on how many VMs or Containers a single user can run for free for public repositories:
 
-  * 8 Linux Containers or VMs
-  * 2 Windows Containers or VMs
-  * 2 FreeBSD VMs
-  * 1 macOS VM
+* 8 Linux Containers or VMs
+* 2 Windows Containers or VMs
+* 2 FreeBSD VMs
+* 1 macOS VM
   
 Which means that a single user can run at most 13 simultaneous tasks for free.
 
@@ -39,19 +39,19 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
     For example, if you have 10 active contributors to a repository then you can end up with 130 tasks running in parallel 
     for the repository.  
 
-#### CI agent stopped responding!
+## CI agent stopped responding!
 
 It means that Cirrus CI haven't heard from the agent for quite some time. In 99.999% of the cases 
 it happens because of two reasons:
 
 1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster). Community Cluster 
-is backed by Google Cloud's [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
-Google Cloud preempted back a VM your task was executing on. Cirrus CI is trying to minimize possibility of such cases 
-by constantly rotating VMs before Google Cloud preempts them, but there is still chance of such inconvenience.
+   is backed by Google Cloud's [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
+   Google Cloud preempted back a VM your task was executing on. Cirrus CI is trying to minimize possibility of such cases 
+   by constantly rotating VMs before Google Cloud preempts them, but there is still chance of such inconvenience.
 
 2. Your CI task used too much memory which led to a crash of a VM or a container.
 
-#### Instance failed to start!
+## Instance failed to start!
 
 It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services.md) 
 to allocate resources. But a requested resource wasn't created. 
@@ -59,7 +59,7 @@ to allocate resources. But a requested resource wasn't created.
 If it happened for an OSS project, please contact [support](/support.md) immediately. Otherwise check your cloud console first 
 and then contact [support](/support.md) if it's still not clear what happened. 
 
-#### Instance got rescheduled!
+## Instance got rescheduled!
 
 Cirrus CI is trying to be as efficient as possible and uses an auto-scalable cluster of [preemptible VMs](https://cloud.google.com/preemptible-vms/)
 to run [Linux containers for OSS](/guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
@@ -71,7 +71,7 @@ This is a rare event since autoscaler is constantly rotating instances but preem
 !!! tip "Compute Credits"
     Tasks that use [compute credits](/pricing.md#compute-credits) are executed on standard VMs that don't get preempted.    
 
-#### Instance timed out!
+## Instance timed out!
 
 By default Cirrus CI has an execution limit of 60 minutes for each task. However, this default timeout duration can be changed
 by using `timeout_in` field in `.cirrus.yml` configuration file:
@@ -82,12 +82,12 @@ task:
   ...
 ```
 
-#### Only GitHub Support?
+## Only GitHub Support?
 
 At the moment Cirrus CI only supports GitHub via a [GitHub Application](https://github.com/apps/cirrus-ci). We are planning
 to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) next. 
 
-#### Any discounts?
+## Any discounts?
 
 Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services.md#community-cluster) 
 which is free for open source projects. But since Cirrus CI delegates execution of builds to different computing services,

--- a/docs/guide/FreeBSD.md
+++ b/docs/guide/FreeBSD.md
@@ -16,7 +16,7 @@ task:
     Under the hood a simple integration with [Google Compute Engine](/guide/supported-computing-services.md#compute-engine) 
     is used.
 
-### List of available images
+## List of available images
 
 Any of the official FreeBSD VMs on Google Cloud Platform are supported. Here are a few of them which are self explanatory:
 

--- a/docs/guide/build-life.md
+++ b/docs/guide/build-life.md
@@ -18,7 +18,7 @@ of the commands upon execution.
 
 Once task finishes the same scheduling service will clean up a VM or a container.
 
-![](/assets/images/cirrus-ci-communication.svg)
+![communication schema](/assets/images/cirrus-ci-communication.svg)
 
 Image above is a diagram of how Cirrus CI schedules a task on Google Cloud Platform. <span style="color:#2196F3">Blue arrows</span> 
 represent API calls and <span style="color:#AED581">green arrow</span> represents unidirectional communication between 
@@ -28,5 +28,3 @@ Other things like health checking of the agent and GitHub status reporting are h
 but the main flow was described above. Straight forward and nothing magical. :sweat_smile:
 
 For any question please use official [support channels](/support.md).
-
-

--- a/docs/guide/macOS.md
+++ b/docs/guide/macOS.md
@@ -11,11 +11,11 @@ task:
   script: ...
 ```
 
-### List of available images
+## List of available images
 
 * `mojave-base` - vanilla macOS with Brew and Command Line Tools pre-installed.
-* `mojave-xcode-10.1` - based of `mojave-base` with Xcode and couple other packages pre-installed:
-`cocoapods`, `fastlane`, `rake` and `xctool`.
+* `mojave-xcode-10.1` - based of `mojave-base` with Xcode and couple other packages pre-installed: 
+  `cocoapods`, `fastlane`, `rake` and `xctool`.
 * `high-sierra-base` - vanilla macOS with Brew and Command Line Tools pre-installed.
 * `high-sierra-xcode-9.4.1` and `high-sierra-xcode-10.0` - based on `high-sierra-base` with Xcode and couple other packages pre-installed: `cocoapods`, `fastlane`, `rake` and `xctool`.
 

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -8,7 +8,7 @@ Here is a full list of curated Cirrus Actions for GitHub including ones to send 
 Email GitHub Action allows to send email notifications on Cirrus CI Checks completion. Simply add the following to you
 `.github/main.workflow` workflow file:
 
-```
+```HCL
 action "Cirrus CI Email" {
   uses = "docker://cirrusactions/email:latest"
   env = {

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -33,24 +33,24 @@
 For every [task](writing-tasks.md) Cirrus CI starts a new Virtual Machine or a new Docker Container on a given compute service.
 Using a new VM or a new Docker Container each time for running tasks has many benefits:
 
-  * **Atomic changes to an environment where tasks are executed.** Everything about a task is configured in `.cirrus.yml` file including
-    VM image version and Docker Container image version. After commiting changes to `.cirrus.yml` not only new tasks will use the new environment
-    but also outdated branches will continue using the old configuration.
-  * **Reproducibility.** Fresh environment guarantees no corrupted artifacts or caches are presented from the previous tasks.
-  * **Cost efficiency.** Most compute services are offering per-second pricing which makes them ideal for using with Cirrus CI. 
-    Also each task for repository can define ideal amount of CPUs and Memory specific for a nature of the task. No need to manage
-    pools of similar VMs or try to fit workloads within limits of a given Continuous Integration systems.
+* **Atomic changes to an environment where tasks are executed.** Everything about a task is configured in `.cirrus.yml` file including
+  VM image version and Docker Container image version. After commiting changes to `.cirrus.yml` not only new tasks will use the new environment
+  but also outdated branches will continue using the old configuration.
+* **Reproducibility.** Fresh environment guarantees no corrupted artifacts or caches are presented from the previous tasks.
+* **Cost efficiency.** Most compute services are offering per-second pricing which makes them ideal for using with Cirrus CI. 
+  Also each task for repository can define ideal amount of CPUs and Memory specific for a nature of the task. No need to manage
+  pools of similar VMs or try to fit workloads within limits of a given Continuous Integration systems.
 
 To be fair there are of course some disadvantages of starting a new VM or a container for every task:
 
-  * **Virtual Machine Startup Speed.** Starting a VM can take from a few dozen seconds to a minute or two depending on a cloud provider and
-    a particular VM image. Starting a container on the other hand just takes a few hundred milliseconds! But even a minute
-    on average for starting up VMs is not a big inconvenience in favor of more stable, reliable and more reproducible CI.
-  * **Cold local caches for every task execution.** Many tools tend to store some caches like downloaded dependencies locally
-    to avoid downloading them again in future. Since Cirrus CI always uses fresh VMs and containers such local caches will always
-    be empty. Performance implication of empty local caches can be avoided by using Cirrus CI features like 
-    [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can 
-    even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
+* **Virtual Machine Startup Speed.** Starting a VM can take from a few dozen seconds to a minute or two depending on a cloud provider and
+  a particular VM image. Starting a container on the other hand just takes a few hundred milliseconds! But even a minute
+  on average for starting up VMs is not a big inconvenience in favor of more stable, reliable and more reproducible CI.
+* **Cold local caches for every task execution.** Many tools tend to store some caches like downloaded dependencies locally
+  to avoid downloading them again in future. Since Cirrus CI always uses fresh VMs and containers such local caches will always
+  be empty. Performance implication of empty local caches can be avoided by using Cirrus CI features like 
+  [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can 
+  even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
 
 Please check the list of currently supported cloud compute services below and please see what's [coming next](#coming-soon).
 
@@ -364,7 +364,6 @@ candidate for running modern CI workloads. ACI allows *just* to run Linux and Wi
 underlying infrastructure.
 
 Once `azure_credentials` is configured as described above, tasks can be scheduled on ACI by configuring `aci_instance` like this:
-
 
 ```yaml
 azure_container_instance:

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -465,7 +465,7 @@ Additional container can be very handy in many scenarios. Please check [Cirrus C
 
 Cirrus CI provides a way to embed a badge that can represent status of your builds into a ReadMe file or a website.
 
-For example, this is a badge for `cirruslabs/cirrus-ci-web` repository that contains Cirrus CI's front end: [![passing badge](https://api.cirrus-ci.com/github/cirruslabs/cirrus-ci-web.svg)](https://github.com/cirruslabs/cirrus-ci-web)
+For example, this is a badge for `cirruslabs/cirrus-ci-web` repository that contains Cirrus CI's front end: [![Passing build badge example](https://api.cirrus-ci.com/github/cirruslabs/cirrus-ci-web.svg)](https://github.com/cirruslabs/cirrus-ci-web)
 
 In order to embed such a check into your ReadMe file or your website, simply use a URL to a badge that looks like this:
 

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -204,8 +204,8 @@ CIRRUS_WORKING_DIR | `cirrus-ci-build` folder inside of a system's temporary fol
 It is possible to securely add sensitive information to `.cirrus.yml` file. Encrypted variables are only available to
 builds initialized or approved by users with write permission to a corresponding repository.
 
-In order to encrypt a variable go to repository's settings page via clicking settings icon ![](https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_settings_black_24px.svg)
-on a repository's main page (for example https://cirrus-ci.com/github/my-organization/my-repository) and follow instructions.
+In order to encrypt a variable go to repository's settings page via clicking settings icon ![settings icon](https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_settings_black_24px.svg)
+on a repository's main page (for example `https://cirrus-ci.com/github/my-organization/my-repository`) and follow instructions.
 
 !!! warning
     Only users with `WRITE` permissions can add encrypted variables to a repository.
@@ -465,7 +465,7 @@ Additional container can be very handy in many scenarios. Please check [Cirrus C
 
 Cirrus CI provides a way to embed a badge that can represent status of your builds into a ReadMe file or a website.
 
-For example, this is a badge for `cirruslabs/cirrus-ci-web` repository that contains Cirrus CI's front end: [![](https://api.cirrus-ci.com/github/cirruslabs/cirrus-ci-web.svg)](https://github.com/cirruslabs/cirrus-ci-web)
+For example, this is a badge for `cirruslabs/cirrus-ci-web` repository that contains Cirrus CI's front end: [![passing badge](https://api.cirrus-ci.com/github/cirruslabs/cirrus-ci-web.svg)](https://github.com/cirruslabs/cirrus-ci-web)
 
 In order to embed such a check into your ReadMe file or your website, simply use a URL to a badge that looks like this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,10 +60,10 @@ patterns from Cirrus CI customers:
 * Bring you own infrastructure by delegating execution directly to [variety of computing services](guide/supported-computing-services.md).
 * Flexible execution environment: any Unix or Windows VM, any Docker container, any amount of CPUs, optional SSDs and GPUs.
 * Simple but very powerful configuration format. Learn more about how to configure tasks [here](guide/writing-tasks.md). Configure things like:
-    - [Matrix Builds](guide/writing-tasks.md#matrix-modification)
-    - [Dependencies between tasks](guide/writing-tasks.md#dependencies)
-    - [Conditional Task Execution](guide/writing-tasks.md#conditional-task-execution)
-    - [Local HTTP Cache](guide/writing-tasks.md#http-cache)
+    * [Matrix Builds](guide/writing-tasks.md#matrix-modification)
+    * [Dependencies between tasks](guide/writing-tasks.md#dependencies)
+    * [Conditional Task Execution](guide/writing-tasks.md#conditional-task-execution)
+    * [Local HTTP Cache](guide/writing-tasks.md#http-cache)
 
 Try Cirrus CI with a [Quick Start](guide/quick-start.md) guide.
 

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable -->
+
 # Privacy Policy
 
 In addition to these Terms of Service, Cirrus Labs also has a [Terms of Service](terms.md).

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable -->
+
 # Terms of Service
 
 In addition to these Terms of Service, Cirrus Labs also has a [Privacy Policy](privacy.md).

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -3,7 +3,7 @@
 Cirrus CI is free for Open Source projects. For private projects Cirrus CI has couple of options depending on your needs:
 
 1. For private personal repositories these is a [very affordable $10 a month plan](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTI=#pricing-and-setup) with 
-ultimate access to community clusters for [Linux](/guide/linux.md), [Windows](/guide/windows.md) and [macOS](/guide/macOS.md) workloads.
+   ultimate access to community clusters for [Linux](/guide/linux.md), [Windows](/guide/windows.md) and [macOS](/guide/macOS.md) workloads.
 2. Configure access to your own [compute services](#compute-services) and [pay $10/seat/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTM=#pricing-and-setup)
    fee for orchestrating your CI workloads on these compute services.
 3. Buy [compute credits](#compute-credits) to access managed and pre-configured community clusters for [Linux](/guide/linux.md), [Windows](/guide/windows.md) and [macOS](/guide/macOS.md) workloads.
@@ -15,22 +15,22 @@ User | Public Repository | Private Repository
 Person | Free + Access to community cluster | [$10/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTI=#pricing-and-setup) + Access to community cluster
 Organization | Free + Access to community cluster | <ul><li>[$10/seat/month](#compute-services) for managing CI workloads on your [compute services](#compute-services)</li><li>Buy [compute credits](#compute-credits) to access community clusters</li></ul> 
 
-### Compute Services
+## Compute Services
 
 Configure and connect one or several [compute services](/guide/supported-computing-services.md) to Cirrus CI and [pay $10/seat/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTM=#pricing-and-setup) 
 for orchestrating CI workloads on these compute services. 
 
 **Pros** of this approach:
 
-  * Full control of underlying infrastructure. Any type of VMs and containers with any amount of CPUs and memory.
-  * Most secure. Setup any firewall and access rules.
-  * Pay for CI within your existing cloud and GitHub bills. 
+* Full control of underlying infrastructure. Any type of VMs and containers with any amount of CPUs and memory.
+* Most secure. Setup any firewall and access rules.
+* Pay for CI within your existing cloud and GitHub bills. 
   
 **Cons** of this approach:
 
-  * Need to configure and connect one or several [compute services](/guide/supported-computing-services.md). Might be
-    nonintuitive for cases like Anka Build Cloud for macOS.
-  * Might not worth the effort for a small team.
+* Need to configure and connect one or several [compute services](/guide/supported-computing-services.md). Might be
+  nonintuitive for cases like Anka Build Cloud for macOS.
+* Might not worth the effort for a small team.
 
 !!! info "What is a seat?"
 
@@ -43,7 +43,7 @@ for orchestrating CI workloads on these compute services.
     
     In that case there are `5 + 1 = 6` seats you need to purchase Cirrus CI plan for.
     
-### Compute Credits
+## Compute Credits
 
 Sometimes configuring your own [compute services](#compute-services) isn't worth it. It takes time and effort to configure
 and maintain them. For such cases there is a way to use the same community clusters that the Open Source community is enjoying.
@@ -51,10 +51,10 @@ Use compute credits with your private or public repositories of any scale.
 
 1 compute credit can be bought for 1 US dollar. Here is how much 1000 minutes of CPU time will cost for different platforms:
 
-  * 1000 minutes of 1 virtual CPU for Linux for 5 compute credits
-  * 1000 minutes of 1 virtual CPU for FreeBSD for 5 compute credits
-  * 1000 minutes of 1 virtual CPU for Windows for 10 compute credits
-  * 1000 minutes of 1 CPU with hyper-threading enabled (comparable to 2 vCPUs) for macOS for 30 compute credits
+* 1000 minutes of 1 virtual CPU for Linux for 5 compute credits
+* 1000 minutes of 1 virtual CPU for FreeBSD for 5 compute credits
+* 1000 minutes of 1 virtual CPU for Windows for 10 compute credits
+* 1000 minutes of 1 CPU with hyper-threading enabled (comparable to 2 vCPUs) for macOS for 30 compute credits
 
 All tasks using compute credits are charged on per-second basis. 2 CPU Linux task takes 2 minutes? Pay **2 cents**.
 
@@ -67,17 +67,17 @@ All tasks using compute credits are charged on per-second basis. 2 CPU Linux tas
 
 **Pros** of this approach:
   
-  * Use the same pre-configured infrastructure as the Open Source community is enjoying.
-  * No need to configure anything. Let Cirrus CI team manage and upgrade infrastructure for you.
-  * Per-second billing with no additional minimum or monthly fees.
-  * Cost efficient for small teams. 
+* Use the same pre-configured infrastructure as the Open Source community is enjoying.
+* No need to configure anything. Let Cirrus CI team manage and upgrade infrastructure for you.
+* Per-second billing with no additional minimum or monthly fees.
+* Cost efficient for small teams. 
   
 **Cons** of this approach:
   
-  * Not cost efficient for big teams.
-  * No support for exotic use cases like GPUs, SSDs and 100+ cores machines.
+* Not cost efficient for big teams.
+* No support for exotic use cases like GPUs, SSDs and 100+ cores machines.
 
-#### Buying Compute Credits
+### Buying Compute Credits
 
 To see your current balance, recent transactions and to buy more compute credits go to your organization's settings page:
 
@@ -89,7 +89,7 @@ https://cirrus-ci.com/settings/github/MY-ORGANIZATION
     Every organization on GitHub gets 60 compute credits upon Cirrus CI App installation. It has never been easier to try
     Cirrus CI on private organizational repositories.
 
-#### Configuring Compute Credits
+### Configuring Compute Credits
 
 Compute credits can be used with any of the following instance types: `container`, `windows_container` and `osx_instance`.
 No additional configuration needed.

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,4 +1,4 @@
-## Why Cirrus CI
+# Why Cirrus CI
 
 * "Why yet another CI? There are gazillions of them already!"
 * "We have X already configured. It's working for us. Why should we switch?"
@@ -22,11 +22,11 @@ but they are doing great job of making continuous integration as simple as possi
 inconveniences like:
 
 * Not pay-as-you-go approach for pricing. Usually users pay for how many containers at a time one can execute. 
-Which means if users don't want to face queuing issues they need to plan and pay for the maximum load they'll have. 
-This is not a suitable pricing model for the era of cloud computing.
+  Which means if users don't want to face queuing issues they need to plan and pay for the maximum load they'll have. 
+  This is not a suitable pricing model for the era of cloud computing.
 * Focused mostly on containers which many businesses have not yet migrated their legacy projects to.
 * Poor environment flexibility. It's not possible to specify precisely which VM image or Docker container to run and
-how much resources it can have.
+  how much resources it can have.
 
 Because of all the problems and inconveniences described above, we decided to build Cirrus CI with three simple principles in mind:
 


### PR DESCRIPTION
I went through a rabbit hole while reviewing https://github.com/cirruslabs/cirrus-ci-docs/pull/127 and found another solution via https://github.com/DavidAnson/markdownlint. It allows nicely configure linting rules via a YAML config file (`.markdownlint.yml`). It's particularly great because some of the rules are very noisy and some rules are conflicting with `mkdocs` (for example, sub-list should be indented with 4 spaces according to `mkdocs` instead of 2 like `markdownlint` requires by default). 

Might be a good follow up to reenable some of them.

@RDIL PTAL. What do you think about this take?