### PR TITLE
Start to fix

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,8 +83,8 @@ task:
 ```
 
 !!! note "Maximum timeout"
-    There is a hard limit of 2 hours for community tasks. Use [compute credits](/pricing.md#compute-credits) or
-    [compute service integration](/guide/supported-computing-services.md) to avoid the limit.
+    There is a hard limit of 2 hours for community tasks. Use [compute credits](/pricing#compute-credits) or
+    [compute service integration](/guide/supported-computing-services) to avoid the limit.
 
 ## Only GitHub Support?
 
@@ -93,6 +93,6 @@ to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) ne
 
 ## Any discounts?
 
-Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services.md#community-cluster) 
+Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services#community-cluster) 
 which is free for open source projects. But since Cirrus CI delegates execution of builds to different computing services,
 it means that discounts from your cloud provider will be applied to Cirrus CI builds.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 ## Is Cirrus CI a delivery platform?
 
 Cirrus CI is not positioned as a delivery platform but can be used as one for many general use cases by having 
-[Dependencies](guide/writing-tasks.md#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks.md#conditional-task-execution):
+[Dependencies](guide/writing-tasks#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks#conditional-task-execution):
 
 ```yaml
 lint_task:
@@ -22,8 +22,8 @@ publish_task:
 
 ## Are there any limits?
 
-There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](/guide/supported-computing-services.md)
-or use [Compute Credits](/pricing.md#compute-credits) for either private or public repositories.
+There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](/guide/supported-computing-services)
+or use [Compute Credits](/pricing#compute-credits) for either private or public repositories.
 
 Cirrus CI has following limitations on how many VMs or Containers a single user can run for free for public repositories:
 
@@ -44,7 +44,7 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
 It means that Cirrus CI haven't heard from the agent for quite some time. In 99.999% of the cases 
 it happens because of two reasons:
 
-1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster). Community Cluster 
+1. Your task was executing on [Community Cluster](guide/supported-computing-services#community-cluster). Community Cluster 
    is backed by Google Cloud's [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
    Google Cloud preempted back a VM your task was executing on. Cirrus CI is trying to minimize possibility of such cases 
    by constantly rotating VMs before Google Cloud preempts them, but there is still chance of such inconvenience.
@@ -53,23 +53,23 @@ it happens because of two reasons:
 
 ## Instance failed to start!
 
-It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services.md) 
+It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services) 
 to allocate resources. But a requested resource wasn't created. 
 
-If it happened for an OSS project, please contact [support](/support.md) immediately. Otherwise check your cloud console first 
-and then contact [support](/support.md) if it's still not clear what happened. 
+If it happened for an OSS project, please contact [support](/support) immediately. Otherwise check your cloud console first 
+and then contact [support](/support) if it's still not clear what happened. 
 
 ## Instance got rescheduled!
 
 Cirrus CI is trying to be as efficient as possible and uses an auto-scalable cluster of [preemptible VMs](https://cloud.google.com/preemptible-vms/)
-to run [Linux containers for OSS](/guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
+to run [Linux containers for OSS](/guide/linux). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
 that **run tasks for OSS projects free of charge** but it comes with a rare edge case... 
 
 Preemptible VMs can be preempted which will require to reschedule and automatically restart tasks that were executing on these VMs. 
 This is a rare event since autoscaler is constantly rotating instances but preemption still happens occasionally.
 
 !!! tip "Compute Credits"
-    Tasks that use [compute credits](/pricing.md#compute-credits) are executed on standard VMs that don't get preempted.    
+    Tasks that use [compute credits](/pricing#compute-credits) are executed on standard VMs that don't get preempted.    
 
 ## Instance timed out!
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -10,7 +10,7 @@ Choose a plan for your personal account or for an organization you have admin wr
 
 GitHub Apps can be installed on all repositories or on repository-by-repository basis for granular access control. For
 example, Cirrus CI can be installed only on public repositories and will only have access to these public repositories.
-In contrast, classic OAuth Apps [doesn't have such restrictions](https://developer.github.com/apps/differences-between-apps/#what-can-github-apps-and-oauth-apps-access).  
+In contrast, classic OAuth Apps [don't have such restrictions](https://developer.github.com/apps/differences-between-apps/#what-can-github-apps-and-oauth-apps-access).  
 
 <img src="/assets/images/screenshots/github/marketplace/step3.png" />
 
@@ -52,9 +52,9 @@ Newly created PRs will also get Cirrus CI's status checks.
 <img src="/assets/images/screenshots/github/statuses-pr.png" />
 
 !!! info "Examples"
-    Don't forget to check [examples page](/examples.md) for ready-to-copy examples of `.cirrus.yml` configuration files
+    Don't forget to check [examples page](/examples) for ready-to-copy examples of `.cirrus.yml` configuration files
     for different languages and build systems.
 
 !!! info "Life of a build"
     Please check [a high level overview of what's happening under the hood](build-life.md) when a changed is pushed
-    and [this guide](writing-tasks.md) to learn more about how to write tasks.
+    and [this guide](writing-tasks) to learn more about how to write tasks.


### PR DESCRIPTION
Instead of making links relative on GitHub, we should make them relevant in the actual documentation.  Expect another PR when I get 🏠 finishing up making all the links work. 