### PR TITLE
Use relative links everywhere

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -177,7 +177,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 ## MySQL
 
-[Additional Containers feature](/guide/writing-tasks.md#additional-containers) makes it super simple to run the same Docker
+[Additional Containers feature](guide/writing-tasks.md#additional-containers) makes it super simple to run the same Docker
 MySQL image as you might be running in production for your application. Getting a running instance of the latest GA 
 version of MySQL can be as simple as the following six lines in your `.cirrus.yml`:
 
@@ -271,7 +271,7 @@ environment variable. `CIRRUS_RELEASE` indicates release id which can be used to
 
 Cirrus CI only requires write access to Check API and doesn't require write access to repository contents becuase of security 
 reasons. That's why you need to [create a personal access token](https://github.com/settings/tokens/new) with full access
-to `repo` scope. Once an access token is created, please [create an encrypted variable](/guide/writing-tasks.md#encrypted-variables) 
+to `repo` scope. Once an access token is created, please [create an encrypted variable](guide/writing-tasks.md#encrypted-variables) 
 from it and save it to `.cirrus.yml`:
 
 ```yaml

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 ## Is Cirrus CI a delivery platform?
 
 Cirrus CI is not positioned as a delivery platform but can be used as one for many general use cases by having 
-[Dependencies](guide/writing-tasks#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks#conditional-task-execution):
+[Dependencies](guide/writing-tasks.md#dependencies) between tasks and using [Conditional Task Execution](guide/writing-tasks#conditional-task-execution):
 
 ```yaml
 lint_task:
@@ -22,8 +22,8 @@ publish_task:
 
 ## Are there any limits?
 
-There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](/guide/supported-computing-services)
-or use [Compute Credits](/pricing#compute-credits) for either private or public repositories.
+There are no limits on how many VMs or Containers you can run in parallel if you bring your own [compute services](guide/supported-computing-services.md)
+or use [Compute Credits](pricing.md#compute-credits) for either private or public repositories.
 
 Cirrus CI has following limitations on how many VMs or Containers a single user can run for free for public repositories:
 
@@ -44,7 +44,7 @@ Which means that a single user can run at most 13 simultaneous tasks for free.
 It means that Cirrus CI haven't heard from the agent for quite some time. In 99.999% of the cases 
 it happens because of two reasons:
 
-1. Your task was executing on [Community Cluster](guide/supported-computing-services#community-cluster). Community Cluster 
+1. Your task was executing on [Community Cluster](guide/supported-computing-services.md#community-cluster). Community Cluster 
    is backed by Google Cloud's [Preemptible VMs](https://cloud.google.com/preemptible-vms/) for cost efficiency reasons and
    Google Cloud preempted back a VM your task was executing on. Cirrus CI is trying to minimize possibility of such cases 
    by constantly rotating VMs before Google Cloud preempts them, but there is still chance of such inconvenience.
@@ -53,23 +53,23 @@ it happens because of two reasons:
 
 ## Instance failed to start!
 
-It means that Cirrus CI have made a successful API call to a [computing service](/guide/supported-computing-services) 
+It means that Cirrus CI have made a successful API call to a [computing service](guide/supported-computing-services.md) 
 to allocate resources. But a requested resource wasn't created. 
 
-If it happened for an OSS project, please contact [support](/support) immediately. Otherwise check your cloud console first 
-and then contact [support](/support) if it's still not clear what happened. 
+If it happened for an OSS project, please contact [support](support.md) immediately. Otherwise check your cloud console first 
+and then contact [support](support.md) if it's still not clear what happened. 
 
 ## Instance got rescheduled!
 
 Cirrus CI is trying to be as efficient as possible and uses an auto-scalable cluster of [preemptible VMs](https://cloud.google.com/preemptible-vms/)
-to run [Linux containers for OSS](/guide/linux). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
+to run [Linux containers for OSS](guide/linux.md). It allows to drastically lower Cirrus CI's bill for parts of infrastructure 
 that **run tasks for OSS projects free of charge** but it comes with a rare edge case... 
 
 Preemptible VMs can be preempted which will require to reschedule and automatically restart tasks that were executing on these VMs. 
 This is a rare event since autoscaler is constantly rotating instances but preemption still happens occasionally.
 
 !!! tip "Compute Credits"
-    Tasks that use [compute credits](/pricing#compute-credits) are executed on standard VMs that don't get preempted.    
+    Tasks that use [compute credits](pricing.md#compute-credits) are executed on standard VMs that don't get preempted.    
 
 ## Instance timed out!
 
@@ -83,8 +83,8 @@ task:
 ```
 
 !!! note "Maximum timeout"
-    There is a hard limit of 2 hours for community tasks. Use [compute credits](/pricing#compute-credits) or
-    [compute service integration](/guide/supported-computing-services) to avoid the limit.
+    There is a hard limit of 2 hours for community tasks. Use [compute credits](pricing.md#compute-credits) or
+    [compute service integration](guide/supported-computing-services.md) to avoid the limit.
 
 ## Only GitHub Support?
 
@@ -93,6 +93,6 @@ to [support BitBucket](https://github.com/cirruslabs/cirrus-ci-docs/issues/9) ne
 
 ## Any discounts?
 
-Cirrus CI itself doesn't provide any discounts except [Community Cluster](/guide/supported-computing-services#community-cluster) 
+Cirrus CI itself doesn't provide any discounts except [Community Cluster](guide/supported-computing-services.md#community-cluster) 
 which is free for open source projects. But since Cirrus CI delegates execution of builds to different computing services,
 it means that discounts from your cloud provider will be applied to Cirrus CI builds.

--- a/docs/guide/FreeBSD.md
+++ b/docs/guide/FreeBSD.md
@@ -1,6 +1,6 @@
 # FreeBSD Virtual Machines
 
-It is possible to run FreeBSD Virtual Machines the same way one can run [Linux containers](/guide/linux.md) on FreeBSD Community Cluster. 
+It is possible to run FreeBSD Virtual Machines the same way one can run [Linux containers](linux.md) on FreeBSD Community Cluster. 
 Simply use `freebsd_instance` in `.cirrus.yml` files:
 
 ```yaml
@@ -13,7 +13,7 @@ task:
 ```
 
 !!! info "Under the Hood"
-    Under the hood a simple integration with [Google Compute Engine](/guide/supported-computing-services.md#compute-engine) 
+    Under the hood a simple integration with [Google Compute Engine](supported-computing-services.md#compute-engine) 
     is used.
 
 ## List of available images

--- a/docs/guide/docker-builder.md
+++ b/docs/guide/docker-builder.md
@@ -1,5 +1,5 @@
 Docker Builder is a way to build and publish Docker Images to Docker Registries of their choice.
-In essence, a `docker_builder` is basically [a `task`](/guide/writing-tasks.md) that is executed in a VM with pre-installed Docker. 
+In essence, a `docker_builder` is basically [a `task`](writing-tasks.md) that is executed in a VM with pre-installed Docker. 
 `docker_builder` can be defined the same way as a `task`:
 
 ```yaml
@@ -7,8 +7,8 @@ docker_builder:
   build_script: docker build --tag myrepo/foo:latest .
 ```
 
-Leveraging features like [Task Dependencies](/guide/writing-tasks.md#depepndencies), [Conditional Execution](/guide/writing-tasks.md#conditional-execution)
-and [Encrypted Variables](/guide/writing-tasks.md#encrypted-variables) with a Docker Builder can help building some pretty
+Leveraging features like [Task Dependencies](writing-tasks.md#depepndencies), [Conditional Execution](writing-tasks.md#conditional-execution)
+and [Encrypted Variables](writing-tasks.md#encrypted-variables) with a Docker Builder can help building some pretty
 complex pipelines. It can also be used to execute builds which need special privileges.
 
 In the example below, a `docker_builder` will be only executed on a tag creation, once both `test` and `lint` 
@@ -104,4 +104,4 @@ docker_builder:
 ```
 
 !!! tip "Supported OS Versions"
-    See [Windows Containers documentation](/guide/windows.md#os-versions) for a list of supported OS versions.
+    See [Windows Containers documentation](windows.md#os-versions) for a list of supported OS versions.

--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -1,10 +1,10 @@
 ## Linux Containers
 
-Linux Community Cluster is a [Kubernetes](https://kubernetes.io/) cluster running on [Google Kubernetes Engine](/guide/supported-computing-services.md#google-kubernetes-engine)
+Linux Community Cluster is a [Kubernetes](https://kubernetes.io/) cluster running on [Google Kubernetes Engine](supported-computing-services.md#google-kubernetes-engine)
 that is available free of charge for Open Source community. Paying customers can also use Community Cluster for 
-personal private repositories or buy CPU time with [compute credits](/pricing.md#compute-credits) for their private organization repositories.
+personal private repositories or buy CPU time with [compute credits](../pricing.md#compute-credits) for their private organization repositories.
 
-Community Cluster is configured the same way as anyone can configure a personal GKE cluster as [described here](/guide/supported-computing-services.md#google-kubernetes-engine).
+Community Cluster is configured the same way as anyone can configure a personal GKE cluster as [described here](supported-computing-services.md#google-kubernetes-engine).
 
 By default a container is given 2 CPUs and 4 Gb of memory but it can be configured in `.cirrus.yml`:
 
@@ -25,4 +25,4 @@ Containers on Community Cluster can use maximum 8.0 CPUs and up to 24 Gb of memo
     require resources faster it will be scheduled.
 
 !!! info "Privileged Access"
-    If you need to run privileged docker containers, take a look at the [docker builder](/guide/docker-builder.md).
+    If you need to run privileged docker containers, take a look at the [docker builder](docker-builder.md).

--- a/docs/guide/macOS.md
+++ b/docs/guide/macOS.md
@@ -1,6 +1,6 @@
 # macOS Virtual Machines
 
-It is possible to run macOS Virtual Machines the same way one can run [Linux containers](/guide/linux.md) on macOS Community Cluster. 
+It is possible to run macOS Virtual Machines the same way one can run [Linux containers](linux.md) on macOS Community Cluster. 
 Simply use `osx_instance` in `.cirrus.yml` files:
 
 ```yaml
@@ -23,5 +23,5 @@ Please refer to [`osx-images`](https://github.com/cirruslabs/osx-images) reposit
 don't hesitate to [create issues](https://github.com/cirruslabs/osx-images/issues) if current images are missing something.
 
 !!! info "Underlying Technology"
-    Under the hood Cirrus CI is using [Anka Cloud hosted on MacStadium](/guide/supported-computing-services.md#anka) for 
-    orchestrating macOS VMs. Please refer to [documentation](/guide/supported-computing-services.md#anka) for more details.
+    Under the hood Cirrus CI is using [Anka Cloud hosted on MacStadium](supported-computing-services.md#anka) for 
+    orchestrating macOS VMs. Please refer to [documentation](supported-computing-services.md#anka) for more details.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -52,9 +52,9 @@ Newly created PRs will also get Cirrus CI's status checks.
 <img src="/assets/images/screenshots/github/statuses-pr.png" />
 
 !!! info "Examples"
-    Don't forget to check [examples page](/examples) for ready-to-copy examples of `.cirrus.yml` configuration files
+    Don't forget to check [examples page](../examples.md) for ready-to-copy examples of `.cirrus.yml` configuration files
     for different languages and build systems.
 
 !!! info "Life of a build"
     Please check [a high level overview of what's happening under the hood](build-life.md) when a changed is pushed
-    and [this guide](writing-tasks) to learn more about how to write tasks.
+    and [this guide](writing-tasks.md) to learn more about how to write tasks.

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -407,7 +407,7 @@ Cirrus Labs created [Anka Controller Extended](https://github.com/cirruslabs/ank
 to Anka Cloud's private network and securely expose API for Cirrus CI to connect. 
 
 Please check [Anka Controller Extended Documentation](https://github.com/cirruslabs/anka-controller-extended) for details
-and don't hesitate to reach out [support](/support.md) with any question.
+and don't hesitate to reach out [support](../support.md) with any question.
 
 Once Anka Controller Extended is up and running, Cirrus CI can use it's API to schedule tasks. Simply use `anka_instance`
 in your `.cirrus.yml` file like this: 

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -1,6 +1,6 @@
 # Windows Containers
 
-It is possible to run Windows Containers the same way one can run [Linux containers](/guide/linux.md) on Windows Community Cluster. 
+It is possible to run Windows Containers the same way one can run [Linux containers](linux.md) on Windows Community Cluster. 
 Simply use `windows_container` instead of `container` in `.cirrus.yml` files:
 
 ```yaml
@@ -12,7 +12,7 @@ task:
   script: ...
 ```
 
-Cirrus CI will execute [scripts instructions](/guide/writing-tasks.md#script-instruction) like **Batch scripts**.
+Cirrus CI will execute [scripts instructions](writing-tasks.md#script-instruction) like **Batch scripts**.
     
 ## OS Versions
 
@@ -30,7 +30,7 @@ windows_container:
 # Powershell support
 
 By default Cirrus CI agent executed scripts using `cmd.exe`. It is possible to override default shell executor by providing
-`CIRRUS_SHELL` [environment variable](/guide/writing-tasks.md#environment-variables):
+`CIRRUS_SHELL` [environment variable](writing-tasks.md#environment-variables):
 
 ```yaml
 env:

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -179,7 +179,7 @@ CIRRUS_TAG | Tag name if current build was triggered by a new tag. For example `
 CIRRUS_OS, OS | Host OS. Either `linux`, `windows` or `darwin`.
 CIRRUS_TASK_NAME | Task name
 CIRRUS_TASK_ID | Unique task ID
-CIRRUS_RELEASE | GitHub Release id if current tag was created for a release. Handy for [uploading release assets](/examples.md#release-assets).
+CIRRUS_RELEASE | GitHub Release id if current tag was created for a release. Handy for [uploading release assets](../examples.md#release-assets).
 CIRRUS_REPO_CLONE_TOKEN | Temporary GitHub access token to perform a clone.
 CIRRUS_REPO_NAME | Repository name. For example `my-project`
 CIRRUS_REPO_OWNER | Repository owner (an organization or a user). For example `my-organization`
@@ -421,7 +421,7 @@ myfolder_cache:
 ```
 
 !!! info
-    To see how HTTP Cache can be used with Gradle's Build Cache please check [this example](/examples.md#build-cache).
+    To see how HTTP Cache can be used with Gradle's Build Cache please check [this example](../examples.md#build-cache).
     
 ## Additional Containers
 
@@ -451,15 +451,15 @@ container:
         MYSQL_ROOT_PASSWORD: ""
 ```
 
-Additional container can be very handy in many scenarios. Please check [Cirrus CI catalog of examples](/examples.md) for more details.
+Additional container can be very handy in many scenarios. Please check [Cirrus CI catalog of examples](../examples.md) for more details.
 
 !!! info "Default Resources"
     By default, each additional container will get `0.5` CPU and `512Mi` of memory. These values can be configured as usual
     via `cpu` and `memory` fields.
 
 !!! warning
-    **Note** that `additional_containers` can be used only with [Community Cluster](/guide/supported-computing-services.md#community-cluster) 
-    or [Google's Kubernetes Engine](/guide/supported-computing-services.md#kubernetes-engine).
+    **Note** that `additional_containers` can be used only with [Community Cluster](supported-computing-services.md#community-cluster) 
+    or [Google's Kubernetes Engine](supported-computing-services.md#kubernetes-engine).
 
 ## Embedded Badges
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -3,10 +3,10 @@
 Cirrus CI is free for Open Source projects. For private projects Cirrus CI has couple of options depending on your needs:
 
 1. For private personal repositories these is a [very affordable $10 a month plan](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTI=#pricing-and-setup) with 
-   ultimate access to community clusters for [Linux](/guide/linux.md), [Windows](/guide/windows.md) and [macOS](/guide/macOS.md) workloads.
+   ultimate access to community clusters for [Linux](guide/linux.md), [Windows](guide/windows.md) and [macOS](guide/macOS.md) workloads.
 2. Configure access to your own [compute services](#compute-services) and [pay $10/seat/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTM=#pricing-and-setup)
    fee for orchestrating your CI workloads on these compute services.
-3. Buy [compute credits](#compute-credits) to access managed and pre-configured community clusters for [Linux](/guide/linux.md), [Windows](/guide/windows.md) and [macOS](/guide/macOS.md) workloads.
+3. Buy [compute credits](#compute-credits) to access managed and pre-configured community clusters for [Linux](guide/linux.md), [Windows](guide/windows.md) and [macOS](guide/macOS.md) workloads.
 
 Here is a pricing model of Cirrus CI:
 
@@ -17,7 +17,7 @@ Organization | Free + Access to community cluster | <ul><li>[$10/seat/month](#co
 
 ## Compute Services
 
-Configure and connect one or several [compute services](/guide/supported-computing-services) to Cirrus CI and [pay $10/seat/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTM=#pricing-and-setup) 
+Configure and connect one or several [compute services](guide/supported-computing-services.md) to Cirrus CI and [pay $10/seat/month](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTM=#pricing-and-setup) 
 for orchestrating CI workloads on these compute services. 
 
 **Pros** of this approach:
@@ -28,7 +28,7 @@ for orchestrating CI workloads on these compute services.
   
 **Cons** of this approach:
 
-* Need to configure and connect one or several [compute services](/guide/supported-computing-services.md). Might be
+* Need to configure and connect one or several [compute services](guide/supported-computing-services.md). Might be
   nonintuitive for cases like Anka Build Cloud for macOS.
 * Might not worth the effort for a small team.
 
@@ -62,7 +62,7 @@ All tasks using compute credits are charged on per-second basis. 2 CPU Linux tas
     Tasks that are using compute credits will be prioritized and will be scheduled as fast as possible.
 
 !!! tip "Works for OSS projects"
-    Compute credits can be used for commercial OSS projects to avoid [concurrency limits](/faq.md#are-there-any-limits).
+    Compute credits can be used for commercial OSS projects to avoid [concurrency limits](faq.md#are-there-any-limits).
     Note that only collaborators for the project will be able to use organization's compute credits.
 
 **Pros** of this approach:


### PR DESCRIPTION
Seems mkdocs started failing to treat absolute links correctly. Let's use relative links everywhere.