### PR TITLE
Changed title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ repo_url: https://github.com/cirruslabs/cirrus-ci-docs/
 site_url: https://cirrus-ci.org
 edit_uri: ""
 
-site_name: Cirrus CI
+site_name: Cirrus CI Documentation
 site_author: Cirrus Labs
 site_description: >
   Cirrus CI is a modern Continuous Integration system built for the era of cloud computing.


### PR DESCRIPTION
Changes title from `Cirrus CI` --> `Cirrus CI Documentation`.  This way if you have build logs up in another tab you can tell the two apart.  