### PR TITLE
Change syntax of YAML multiline strings

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -23,14 +23,14 @@ container:
   memory: 10G
 
 check_android_task:
-  create_device_script: >
-    echo no | avdmanager create avd --force \
-        -n test \
+  create_device_script:
+    echo no | avdmanager create avd --force
+        -n test
         -k "system-images;android-18;default;armeabi-v7a"
-  start_emulator_background_script: >
-    $ANDROID_HOME/emulator/emulator \
-        -avd test \
-        -no-audio \
+  start_emulator_background_script:
+    $ANDROID_HOME/emulator/emulator
+        -avd test
+        -no-audio
         -no-window
   wait_for_emulator_script:
     - adb wait-for-device
@@ -65,12 +65,12 @@ Here is an example of how Cirrus CI HTTP Cache can be used with Bazel:
 container:
   image: l.gcr.io/google/bazel:latest
 task:
-  build_script: |
-    bazel build \
-      --spawn_strategy=sandboxed \
-      --strategy=Javac=sandboxed \
-      --genrule_strategy=sandboxed \
-      --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST \
+  build_script:
+    bazel build
+      --spawn_strategy=sandboxed
+      --strategy=Javac=sandboxed
+      --genrule_strategy=sandboxed
+      --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
       //...
 ```
 

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -569,7 +569,7 @@ Git client (if your build environment has it) to do a shallow clone of a single 
 
 ```yaml
 task:
-  clone_script: >
+  clone_script: |
     if [[ -z "$CIRRUS_PR" ]]; then
       git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
       git reset --hard $CIRRUS_CHANGE_IN_REPO


### PR DESCRIPTION
I think it's cleaner with the same result.