### PR TITLE
Clarify GCS Applicability

### DIFF
--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -128,7 +128,7 @@ At last create an [encrypted variable](writing-tasks.md#encrypted-variables) fro
 gcp_credentials: ENCRYPTED[qwerty239abc]
 ```
 
-Now Cirrus CI can store logs and caches for scheduled tasks in Google Cloud Storage. Please check following sections 
+Now Cirrus CI can store logs and caches in Google Cloud Storage for tasks scheduled on either GCE or GKE. Please check following sections 
 with additional instructions about [Compute Engine](#compute-engine) or [Kubernetes Engine](#kubernetes-engine).
 
 ### Compute Engine


### PR DESCRIPTION
Currently, Google Cloud Storage (GCS) can store logs and caches generated
by Cirrus CI builds, but only if those builds take place on the
customer's GKE cluster or GCE VMs. If the builds take place on
the community cluster, the logs aren't shipped to GCS. This change
makes that clearer.