### PR TITLE
Set git user when deploying docs

### DIFF
--- a/.ci/deploy.sh
+++ b/.ci/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
 git config --global user.name "Cirrus CI"
-git config --global user.name "support@cirruslabs.org"
+git config --global user.name "hello@cirruslabs.org"
 git remote set-url origin https://$DEPLOY_TOKEN@github.com/cirruslabs/cirrus-ci-docs/
 mkdocs gh-deploy --force --remote-branch gh-pages

--- a/.ci/deploy.sh
+++ b/.ci/deploy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 
+git config --global user.name "Cirrus CI"
+git config --global user.name "support@cirruslabs.org"
 git remote set-url origin https://$DEPLOY_TOKEN@github.com/cirruslabs/cirrus-ci-docs/
 mkdocs gh-deploy --force --remote-branch gh-pages


### PR DESCRIPTION
Should say `Cirrus CI` now in the commit instead of `Unknown`.
If you prefer it to say the name of an actual user, I can use @RDILBot 's email.