### PR TITLE
Link to annotation support announcement

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -220,7 +220,7 @@ build_and_test_task:
 
 #### Artifact Format
 
-Cirrus CI supports parsing artifacts in order to extract information that can be presented in the UI for better user experience.
+Cirrus CI supports parsing artifacts in order to extract information that can be presented in the UI for a [better user experience](https://medium.com/cirruslabs/github-annotations-support-227d179cde31).
 Simply use `format` field of an artifact instruction to specify artifact's format:
 
 ```yaml


### PR DESCRIPTION
Previously, it was unclear what kind of changes to the user experience would result from adding JUnit XML artifacts to the CI build. These changes add a link to the blog post announcing support for GitHub Annotations added based on JUnit XML artifacts, which is the main way by which JUnit XML artifact output is presented to the user.