### PR TITLE
Adding tip how to avoid build failures in forked repos

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -398,7 +398,7 @@ a relation between an encrypted variable and a repository for which the encrypte
 
     ```yaml
     task:
-      name: task requiring decrypted variable
+      name: Task requiring decrypted variables
       only_if: $CIRRUS_REPO_OWNER == 'my-organization'
       ...
     ```

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -392,6 +392,21 @@ a relation between an encrypted variable and a repository for which the encrypte
       CREDENTIALS: SECURED[!qwerty] # won't be decrypted in any case
     ```
 
+!!! tip "Skipping Task in Forked Repository"
+    In forked repository the decryption of variable fails, which causes failure of task depending on it.
+    To avoid this by default, make the sensitive task conditional:
+
+    ```yaml
+    task:
+      name: task requiring decrypted variable
+      only_if: $CIRRUS_REPO_OWNER == 'my-organization'
+      ...
+    ```
+
+    Owner of forked repository can re-enable the task, if they have the required sensitive data, by encrypting
+    the variable by themselves and editing both the encrypted variable and repo-owner condition
+    in the `.cirrus.yml` file.
+
 ## Matrix Modification
 
 Sometimes it's useful to run the same task against different software versions. Or run different batches of tests based

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -372,14 +372,14 @@ the same organization cannot re-use them. `qwerty239abc` from the example above 
 variable, it's just an internal ID. No one can brute force your secrets from such ID. In addition, Cirrus CI doesn't know
 a relation between an encrypted variable and a repository for which the encrypted variable was created.
 
-!!! tip "Organization Level Encrypted Variables"
+??? tip "Organization Level Encrypted Variables"
     Sometimes there might be secrets that are used in almost all repositories of an organization. For example, credentials
     to a [compute service](supported-computing-services.md) where tasks will be executed. In order to create such sharable
     encrypted variable go to organization's settings page via clicking settings icon ![settings icon](https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_settings_black_24px.svg)
     on an organization's main page (for example `https://cirrus-ci.com/github/my-organization`) and follow instructions
     in *Organization Level Encrypted Variables* section.
     
-!!! warning "Encrypted Variable for Cloud Credentials"
+??? warning "Encrypted Variable for Cloud Credentials"
     In case you use integration with [one of supported computing services](supported-computing-services.md), an encrypted variable
     used to store credentials that Cirrus is using to communicate with the computing service won't be decrypted if used
     in [environment variables](#encrypted-variables). These credentials have too many permissions for most of the cases,
@@ -392,7 +392,7 @@ a relation between an encrypted variable and a repository for which the encrypte
       CREDENTIALS: SECURED[!qwerty] # won't be decrypted in any case
     ```
 
-!!! tip "Skipping Task in Forked Repository"
+??? tip "Skipping Task in Forked Repository"
     In forked repository the decryption of variable fails, which causes failure of task depending on it.
     To avoid this by default, make the sensitive task conditional:
 


### PR DESCRIPTION
After thinking about your support response, this is more than workaround, this seems actually like proper solution.

Although I have two doubts about this (addition to docs):

1) the condition in YML is straight giveaway of to whom the encrypted variable belongs to. Is this sensitive? (WRT forked repositories probably not, because anyone can check what is the upstream repo and who owns it).

2) why my initial approach trying to base condition on encrypted variable content failed. I guess it's about lifecycle, the decrypted variable is available only after the `only_if` was already processed? And I guess there's no simple way to decrypt it earlier, as that would likely prolong the duration and space where the decrypted data have to exist, which will surely not help the overall security.

Besides that I find in the end the test of repo_owner against some string cleaner solution than regex of the result of decryption.