### PR TITLE
Update Gradle cache doc to also delete buildSrc.jar in cleanup script.

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -200,6 +200,7 @@ check_task:
     - rm -rf ~/.gradle/caches/$GRADLE_VERSION/
     - rm -rf ~/.gradle/caches/transforms-1
     - rm -rf ~/.gradle/caches/journal-1
+    - rm -rf ~/.gradle/caches/jars-3/*/buildSrc.jar
     - find ~/.gradle/caches/ -name "*.lock" -type f -delete
 ```
 


### PR DESCRIPTION
For Gradle projects using the `buildSrc` directory, a new `buildSrc.jar` file is also generated for each build.

Here's a [build](https://cirrus-ci.com/task/6525011615023104) with a new `buildSrc.jar` generated.

```
Cache gradle has changed!
List of changes for /root/.gradle/caches:
created: jars-3/dd29c3dd6da5eb2e25571d03653969af/buildSrc.jar
```

[This](https://cirrus-ci.com/task/5206801426939904) one could skip the upload after removing all `buildSrc.jar` files at the end of the task.