### PR TITLE
Update link to issue creation in Support page

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -2,7 +2,7 @@
 
 The best way to ask general questions about a particular use cases is to email us at [support+ci@cirruslabs.org](mailto:support+ci@cirruslabs.org).
 
-If you have a feature request or noticed lack of some documentation please feel free to [create a GitHub issue](https://github.com/cirruslabs/cirrus-ci-com/issues/new).
+If you have a feature request or noticed lack of some documentation please feel free to [create a GitHub issue](https://github.com/cirruslabs/cirrus-ci-docs/issues/new/choose).
 Our support team will answer it by replying or updating documentation.
 
 ## Migration Assistance


### PR DESCRIPTION
1. Repository was renamed, as I see.
2. Direct to issue template choosing instead of just blank form.