### PR TITLE
remove chown step from yaml snippet for turning on kvm

### DIFF
--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -56,9 +56,7 @@ task:
   container:
     image: cirrusci/android-sdk:29
     kvm: true
-  accel_check_script:
-    - sudo chown cirrus:cirrus /dev/kvm
-    - emulator -accel-check
+  accel_check_script: emulator -accel-check
 ```
 
 !!! warning "Scheduling Times of KVM-enabled Containers"


### PR DESCRIPTION
updating the docs since the chown step is no longer needed

cc @fkorotkov