### PR TITLE
Cache Rust builds in addition to crate downloads

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -656,8 +656,11 @@ container:
   image: rust:latest
 
 test_task:
-  cargo_cache:
+  registry_cache:
     folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
     fingerprint_script: cat Cargo.lock
   build_script: cargo build
   test_script: cargo test
@@ -683,8 +686,11 @@ test_task:
     - allow_failures: true
       container:
         image: rustlang/rust:nightly
-  cargo_cache:
+  registry_cache:
     folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
     fingerprint_script: cat Cargo.lock
   build_script: cargo build
   test_script: cargo test

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -661,7 +661,9 @@ test_task:
     fingerprint_script: cat Cargo.lock
   target_cache:
     folder: target
-    fingerprint_script: cat Cargo.lock
+    fingerprint_script:
+      - rustc --version
+      - cat Cargo.lock
   build_script: cargo build
   test_script: cargo test
   before_cache_script: rm -rf $CARGO_HOME/registry/index
@@ -691,7 +693,9 @@ test_task:
     fingerprint_script: cat Cargo.lock
   target_cache:
     folder: target
-    fingerprint_script: cat Cargo.lock
+    fingerprint_script:
+      - rustc --version
+      - cat Cargo.lock
   build_script: cargo build
   test_script: cargo test
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
- Cache `target` folder so that crate builds can be cached
- Rename `cargo_cache` to `registry_cache` to avoid ambiguity, since both cache folders are Cargo-related