### PR TITLE
Examples: document XCLogParser annotations support

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -176,3 +176,4 @@ RuboCop
 natively
 machine-parsable
 Qodana
+XCLogParser

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -745,3 +745,27 @@ test_task:
       test_script: cargo test --all --all-targets
       before_cache_script: rm -rf $HOME/.cargo/registry/index
     ```
+
+## XCLogParser
+
+[XCLogParser](https://github.com/spotify/XCLogParser) is a CLI tool that parses Xcode and `xcodebuild`'s logs (`xcactivitylog` files) and produces reports in different formats.
+
+Here is an example of `.cirrus.yml` configuration file which will save XCLogParser's flat JSON report as an artifact, will parse it and report as [annotations](https://cirrus-ci.org/guide/writing-tasks/#artifact-parsing):
+
+```yaml
+macos_instance:
+  image: big-sur-xcode
+
+task:
+  name: XCLogParser
+  build_script:
+    - xcodebuild -scheme noapp -derivedDataPath ~/dd
+  always:
+    xclogparser_parse_script:
+      - brew install xclogparser
+      - xclogparser parse --project noapp --reporter flatJson --output xclogparser.json --derived_data ~/dd
+    xclogparser_upload_artifacts:
+      path: "xclogparser.json"
+      type: text/json
+      format: xclogparser
+```

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -302,8 +302,9 @@ Currently, Cirrus CI supports:
 * [GolangCI Lint's JSON format](../examples.md#golangci-lint)
 * [JUnit's XML format](../examples.md#junit)
     * [Python's Unittest format](../examples.md#unittest-annotations)
+* [XCLogParser](../examples.md#xclogparser)
 * [JetBrains Qodana](../examples.md#qodana)
-  
+
 Please [let us know](https://github.com/cirruslabs/cirrus-ci-annotations/issues/new) what kind of formats Cirrus CI should support next!
 
 ### File Instruction


### PR DESCRIPTION
Was added in https://github.com/cirruslabs/cirrus-ci-annotations/pull/27.