### PR TITLE
Clarify max CPUs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,6 +32,8 @@ for public repositories for free:
 * 8.0 CPUs for FreeBSD VMs.
 * 12.0 CPUs macOS VM (1 VM).
 
+Note that a single task can't request more than 8 CPUs (except macOS VMs which are not configurable).
+
 !!! note "No Monthly Minute Limit"
     There are no limits on how many minutes a month you can use! Please keep in mind that mining cryptocurrency is against our Terms of Service, and will most likely be blocked by firewall rules and other anti-fraud mechanisms. Be a good citizen in the OSS community!
 

--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -19,7 +19,7 @@ task:
 ``` 
 
 Containers on Community Cluster can use maximum 8.0 CPUs and up to 32 GB of memory. Memory limit is tight to the amount
-of CPUs requests. Each CPU can't get more than 4G of memory.
+of CPUs requested. For each CPU you can't get more than 4G of memory.
 
 ??? warning "Scheduling Times on Community Cluster"
     Since Community Cluster is shared, scheduling times for containers can vary from time to time. Also, the smaller a container 

--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -21,6 +21,8 @@ task:
 Containers on Community Cluster can use maximum 8.0 CPUs and up to 32 GB of memory. Memory limit is tight to the amount
 of CPUs requested. For each CPU you can't get more than 4G of memory.
 
+Tasks using [Compute Credits](../pricing.md#compute-credits) has higher limits and can use up to 28.0 CPUs and 112G of memory respectively.
+
 ??? warning "Scheduling Times on Community Cluster"
     Since Community Cluster is shared, scheduling times for containers can vary from time to time. Also, the smaller a container 
     require resources the faster it will be scheduled.

--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -6,7 +6,7 @@ personal private repositories or buy CPU time with [compute credits](../pricing.
 
 Community Cluster is configured the same way as anyone can configure a personal GKE cluster as [described here](supported-computing-services.md#google-kubernetes-engine).
 
-By default a container is given 2 CPUs and 4 GB of memory but it can be configured in `.cirrus.yml`:
+By default, a container is given 2 CPUs and 4 GB of memory but it can be configured in `.cirrus.yml`:
 
 ```yaml
 container:
@@ -18,7 +18,8 @@ task:
   script: ...
 ``` 
 
-Containers on Community Cluster can use maximum 8.0 CPUs and up to 24 GB of memory. 
+Containers on Community Cluster can use maximum 8.0 CPUs and up to 32 GB of memory. Memory limit is tight to the amount
+of CPUs requests. Each CPU can't get more than 4G of memory.
 
 ??? warning "Scheduling Times on Community Cluster"
     Since Community Cluster is shared, scheduling times for containers can vary from time to time. Also, the smaller a container 


### PR DESCRIPTION
Historically Cirrus only supported up to 8 CPUs instances on community clusters. When [CPU-based limits](https://medium.com/cirruslabs/new-cpu-based-limits-for-cirrus-ci-b0dcd82f4615) were introduced it appeared that it became possible to request 16.0 cores. But it wasn't desired since all the VMs in the cluster are tuned for running containers with 8.0 cores or less. Recently there was an uptick of people using only 16.0 cores containers, there were so many of them (almost 100 repositories committing pretty frequently) that it started affecting scheduling times, auto-scaling and utilization all together in a bad way.

This PR clarifies the limit which will now be enforced in order to guarantee speedy scheduling times.

PS this only affects community instances.