### PR TITLE
Remove "simply" from the docs (2/2)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -242,7 +242,7 @@ a pre-configured user and as a result don't have `HOME` environment variable pre
 
 ### Caching
 
-To preserve caches between Gradle runs simply add a [cache instruction](guide/writing-tasks.md#cache-instruction) as shown below.
+To preserve caches between Gradle runs, add a [cache instruction](guide/writing-tasks.md#cache-instruction) as shown below.
 The trick here is to clean up `~/.gradle/caches` folder in the very end of a build. Gradle creates some unique nondeterministic
 files in `~/.gradle/caches` folder on every run which makes Cirrus CI re-upload the cache *every time*. This way, you get faster builds!
 
@@ -264,7 +264,7 @@ check_task:
 
 ### Build Cache
 
-Here is how [HTTP Cache](guide/writing-tasks.md#http-cache) can be used with Gradle simply by adding following lines to `settings.gradle`:
+Here is how [HTTP Cache](guide/writing-tasks.md#http-cache) can be used with Gradle by adding the following code to `settings.gradle`:
 
 ```groovy
 ext.isCiServer = System.getenv().containsKey("CIRRUS_CI")
@@ -603,7 +603,7 @@ rspec_task:
 
 !!! tip "Test Parallelization"
     It's super easy to add intelligent test splitting by using [Knapsack Pro](https://knapsackpro.com/) and [matrix modification](guide/writing-tasks.md#matrix-modification).
-    After [setting up Knapsack Pro gem](https://docs.knapsackpro.com/knapsack_pro-ruby/guide/) simply add sharding like this:
+    After [setting up Knapsack Pro gem](https://docs.knapsackpro.com/knapsack_pro-ruby/guide/), you can add sharding like this:
     
     ```yaml
     task:
@@ -626,7 +626,7 @@ rspec_task:
 
 Cirrus CI natively supports [RSpec](https://rspec.info/) and [RuboCop](https://rubocop.org/) machine-parsable JSON reports.
 
-To get behavior-driven test annotations, simply generate a `rspec` artifact from your lint task:
+To get behavior-driven test annotations, generate and upload a `rspec` artifact from your lint task:
 
 ```yaml
 container:

--- a/docs/guide/custom-vms.md
+++ b/docs/guide/custom-vms.md
@@ -14,11 +14,11 @@ Here is an example of using a `compute_engine_instance` to run a VM with KVM ava
 ```yaml
 compute_engine_instance:
   image_project: cirrus-images # GCP project
-  image: family/docker-kvm # family or simply a full image name.
+  image: family/docker-kvm # family or a full image name.
   platform: linux
   cpu: 4 # optional. Defaults to 2 CPUs.
   memory: 16G # optional. Defaults to 4G.
-  disk: 100 # optional. By default uses the smallest disk size required by the image.
+  disk: 100 # optional. By default, uses the smallest disk size required by the image.
   nested_virtualization: true # optional. Whether to enable Intel VT-x. Defaults to false.
 ```
 

--- a/docs/guide/linux.md
+++ b/docs/guide/linux.md
@@ -56,8 +56,8 @@ It is possible to run containers with KVM enabled. Some types of CI tasks can tr
 benefit from native virtualization. For example, Android related tasks can benefit from running hardware accelerated
 emulators instead of software emulated ARM emulators.
 
-In order to enable KVM module for your `container`s, simply add `kvm: true` to your `container` declaration. Here is an
-example of how to configure a task capable of running hardware accelerated Android emulators:
+In order to enable KVM module for your `container`s, add `kvm: true` to your `container` declaration. Here is an
+example of a task that runs hardware accelerated Android emulators:
 
 ```yaml
 task:
@@ -70,8 +70,8 @@ task:
 
 !!! warning "Limitations of KVM-enabled Containers"
     Because of the additional virtualization layer, it takes about a minute to acquire the necessary resources to start such tasks.
-    KVM-enabled containers are backed by dedicated VMs which restrict the amount of CPU resources such tasks can use: the value of `cpu`
-    must be `1` or an even integer. Values like `0.5` or `3` are not supported for KVM-enabled containers 
+    KVM-enabled containers are backed by dedicated VMs which restrict the amount of CPU resources that can be used.
+    The value of `cpu` must be `1` or an even integer. Values like `0.5` or `3` are not supported for KVM-enabled containers 
 
 ### Working with Private Registries
 
@@ -99,8 +99,9 @@ After a successful login, Docker config file located in `~/.docker/config.json` 
 }
 ```
 
-If you don't see `auth` for your registry it means your Docker installation is using a credentials store. In this case
-you can manually auth, it's simply a Base64 encoded string of your username and your PAT ([Personal Access Token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)):
+If you don't see `auth` for your registry, it means your Docker installation is using a credentials store. In this case
+you can manually auth using a Base64 encoded string of your username and your PAT ([Personal Access Token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)).
+Here's how to generate that:
 
 ```bash
 echo $USERNAME:$PAT | base64

--- a/docs/guide/macOS.md
+++ b/docs/guide/macOS.md
@@ -1,7 +1,7 @@
 ## macOS Virtual Machines
 
-It is possible to run macOS Virtual Machines (the same way one can run [Linux containers](linux.md)) on the macOS Community Cluster. 
-Simply use `macos_instance` in your `.cirrus.yml` files:
+It is possible to run macOS Virtual Machines (like how one can run [Linux containers](linux.md)) on the macOS Community Cluster. 
+Use `macos_instance` in your `.cirrus.yml` files:
 
 ```yaml
 macos_instance:

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -6,7 +6,7 @@ Here is a full list of curated Cirrus Actions for GitHub including ones to send 
 ### Email Action
 
 It's possible to facilitate GitHub Action's own email notification mechanism to send emails about Cirrus CI failures. 
-Simply add the following `.github/workflows/email.yml` workflow file:
+To enable it, add the following `.github/workflows/email.yml` workflow file:
 
 ```YAML
 on:

--- a/docs/guide/persistent-workers.md
+++ b/docs/guide/persistent-workers.md
@@ -17,7 +17,7 @@ design difference has multiple benefits comparing to more traditional CIs:
 ### What is a Persistent Worker
 
 For some use cases the traditional CI setup is still useful. However, not everything is available in the cloud. For example,
-Apple releases new ARM-based products and there is simply no virtualization yet available for the new hardware. 
+Apple releases new ARM-based products and there is no virtualization yet available for the new hardware. 
 Another use case is to test the hardware itself, since not everyone is working on websites and mobile apps after all! For such use cases
 it makes sense to go with a traditional CI setup: install some binary on the hardware which will constantly pull for new tasks 
 and will execute them one after another.

--- a/docs/guide/programming-tasks.md
+++ b/docs/guide/programming-tasks.md
@@ -48,7 +48,7 @@ def main(ctx):
   ]
 ```
 
-`main()` simply returns a list of task objects which will be serialized into YAML presentation like this:
+`main()` needs to returns a list of task objects which will be serialized into YAML, like this:
 
 ```yaml
 task:

--- a/docs/guide/programming-tasks.md
+++ b/docs/guide/programming-tasks.md
@@ -48,7 +48,7 @@ def main(ctx):
   ]
 ```
 
-`main()` needs to returns a list of task objects which will be serialized into YAML, like this:
+`main()` needs to return a list of task objects which will be serialized into YAML, like this:
 
 ```yaml
 task:

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -88,9 +88,9 @@ After clicking on `Sign In` you'll be redirected to GitHub in order to authorize
 
 ## Enabling New Repositories after Installation
 
-If you choose initially to allow Cirrus CI to access all of your repositories, simply push a `.cirrus.yml` to start
+If you choose initially to allow Cirrus CI to access all of your repositories, all you need to do is push a `.cirrus.yml` to start
 building your repository on Cirrus CI.
 
-If you choose initially to allow Cirrus CI to access only particular repositories, then first add your new repository to
-the list of repositories Cirrus CI has access to via [this page](https://github.com/apps/cirrus-ci/installations/new) and
+If you only allowed Cirrus CI to access certain repositories, then add your new repository to
+the list of repositories Cirrus CI has access to via [this page](https://github.com/apps/cirrus-ci/installations/new),
 then push a `.cirrus.yml` to start building on Cirrus CI.

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -187,7 +187,7 @@ task:
     ```
 
 !!! tip "Specify Image Family"
-    It's also possible to specify image family instead of the concrete image name. Simply specify `image_family` field
+    It's also possible to specify image family instead of the concrete image name. Use the `image_family` field
     instead of `image_name`:
 
     ```yaml
@@ -246,8 +246,8 @@ task:
 
 #### Docker Containers on Dedicated VMs
 
-It is possible to run a container directly on a Compute Engine VM with pre-installed Docker. Simply use `gce_container`
-to specify a VM image and a Docker container to execute on the VM (`gce_container` simply extends `gce_instance` definition
+It is possible to run a container directly on a Compute Engine VM with pre-installed Docker. Use the `gce_container` field
+to specify a VM image and a Docker container to execute on the VM (`gce_container` extends `gce_instance` definition
 with a few additional fields):
 
 ```yaml

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -1,7 +1,7 @@
 ## Windows Containers
 
-It is possible to run [Windows Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/) the same way one can run [Linux containers](linux.md) on Windows Community Cluster. 
-Simply use `windows_container` instead of `container` in `.cirrus.yml` files:
+It is possible to run [Windows Containers](https://docs.microsoft.com/en-us/virtualization/windowscontainers/about/) like how one can run [Linux containers](linux.md) on Windows Community Cluster. 
+To use Windows, add `windows_container` instead of `container` in `.cirrus.yml` files:
 
 ```yaml
 windows_container:

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -111,12 +111,12 @@ to use with private repositories.
 * Need to pay $10/seat/month plan.
 
 !!! info "What is a seat?"
-    A seat is simply a GitHub user that initiates CI builds by pushing commits and/or creating pull requests in a **private** repository. 
+    A seat is a GitHub user that initiates CI builds by pushing commits and/or creating pull requests in a **private** repository. 
     It can be a real person or a bot. If you are using [Cron Builds](guide/writing-tasks.md#cron-builds) or creating builds through [Cirrus's API](api.md)
     it will be counted as an additional seat (like a bot).
     
     For example, if there are 10 people in your GitHub Organization and only 5 of them are working on private repositories 
-    where Cirrus CI is configured, the remaining 5 people are working on public repositories or not modifying any repositories at all. 
+    where Cirrus CI is configured, the remaining 5 people are not counted as seats, given that they aren't pushing to the private repository. 
     Let's say [Dependabot](https://dependabot.com/) is also configured for these private repositories. 
     
     In that case there are `5 + 1 = 6` seats you need to purchase Cirrus CI plan for.


### PR DESCRIPTION
I have returned, and this time, I've finished off the "simply"s.  They are now gone.  Poof.

I'm going to try to get back into contributing but schoolwork has kept me incredibly busy 😞