### PR TITLE
Added a reference to Persistent Workers

### DIFF
--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -65,7 +65,7 @@ To be fair there are of course some disadvantages of starting a new VM or a cont
   [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can 
   even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
 
-Please check the list of currently supported cloud compute services below. In case you have your own hardware please
+Please check the list of currently supported cloud compute services below. In case you have your own hardware, please
 take a look at [Persistent Workers](persistent-workers.md), which allow connecting anything to Cirrus CI.
 
 ## Google Cloud

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -66,7 +66,7 @@ To be fair there are of course some disadvantages of starting a new VM or a cont
   even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
 
 Please check the list of currently supported cloud compute services below. In case you have your own hardware please
-take a look as [Persistent Workers](persistent-workers.md) which allow connecting anything to Cirrus CI.
+take a look at [Persistent Workers](persistent-workers.md), which allow connecting anything to Cirrus CI.
 
 ## Google Cloud
 

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -65,7 +65,8 @@ To be fair there are of course some disadvantages of starting a new VM or a cont
   [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can 
   even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
 
-Please check the list of currently supported cloud compute services below.
+Please check the list of currently supported cloud compute services below. In case you have your own hardware please
+take a look as [Persistent Workers](persistent-workers.md) which allow connecting anything to Cirrus CI.
 
 ## Google Cloud
 


### PR DESCRIPTION
Just to note that anything can be connected to Cirrus CI even if it's not running in a cloud.