### PR TITLE
Fix ambigious phrasing

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -21,7 +21,7 @@ In contrast, classic OAuth Apps [don't have such restrictions](https://developer
 
 ## Post Installation
 
-Once Cirrus CI is installed for a particular repository, you must add a `.cirrus.yml` configuration to the root of the repository. 
+Once Cirrus CI is installed for a particular repository, you must add either [`.cirrus.yml` configuration](writing-tasks.md) or [`.cirrus.star` script](programming-tasks.md) to the root of the repository. 
 The `.cirrus.yml` defines tasks that will be executed for every build for the repository. 
 
 For a Node.js project, your `.cirrus.yml` could look like:


### PR DESCRIPTION
I may just be idiotic, but I spent like 30 minutes trying to understand why a `.cirrus.yml` file wasn't magically appearing in my repository :smile: 
Make it so that it explcitly says that *you* should add the `.cirrus.yml` file, and not that it should have been created.