### PR TITLE
Adjust macOS pricing

### DIFF
--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -28,7 +28,7 @@ Use compute credits with your private or public repositories of any scale.
 * 1000 minutes of 1 virtual CPU for Linux for 5 compute credits
 * 1000 minutes of 1 virtual CPU for FreeBSD for 5 compute credits
 * 1000 minutes of 1 virtual CPU for Windows for 10 compute credits
-* 1000 minutes of 1 virtual CPU for macOS for 10 compute credits
+* 1000 minutes of 1 virtual CPU for macOS for 40 compute credits
 
 All tasks using compute credits are charged on per-second basis. 2 CPU Linux task takes 2 minutes? Pay **2 cents**.
 


### PR DESCRIPTION
**TLDR:** we are increasing the price for macOS VMs to match [GitHub Actions price](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates) ($0.08 per minute). With the current pricing amortization cost of macOS infrastructure is too high over a long period of time.

It's been almost a year since [we change our macOS infrastructure](https://medium.com/cirruslabs/new-macos-task-execution-architecture-for-cirrus-ci-604250627c94) and can estimate the actual costs over the long period of time.

macOS infrastructure is a snowflake. We are obligated to run macOS on Apple hardware. We cannot scale such infrastructure on demand: we buy physical Mac Minis and deploy them in two datacenters. Now there is a demand for the new Apple Silicon which results in investing a lot of money into having the same amount of CPU power but on a new architecture.

We are increasing pricing to the same price as GitHub Actions. This change will take affect on January 14th.

PS this is unfortunate but without the adjustment we won't be able to provide the same level of support and bring Apple Silicon support later this year.