### PR TITLE
Update GitHub Actions workflow to not trigger on cancelation

### DIFF
--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -17,7 +17,10 @@ name: Email about Cirrus CI failures
 jobs:
   continue:
     name: After Cirrus CI Failure
-    if: github.event.check_suite.app.name == 'Cirrus CI' && github.event.check_suite.conclusion != 'success'
+    if: >-
+      github.event.check_suite.app.name == 'Cirrus CI'
+      && github.event.check_suite.conclusion != 'success'
+      && github.event.check_suite.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
       - uses: octokit/request-action@v2.x


### PR DESCRIPTION
It seems like unnecessary spam to send emails when the build was canceled (both manually and due to a newer build). This will still send an email if you cancel the build or task but there is some other failing task as `failure` has higher priority than `cancelled` when check suite combines all of the check run conclusions.