### PR TITLE
`docker_builder` is not a task field

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -126,7 +126,6 @@ Field Name                 | Managed by | Description
 `container`                | **us**     | [Linux Docker Container][container]
 `arm_container`            | **us**     | [Linux Arm Docker Container][container]
 `windows_container`        | **us**     | [Windows Docker Container][windows_container]
-`docker_builder`           | **us**     | [Full-fledged VM pre-configured for running Docker][docker_builder]
 `macos_instance`           | **us**     | [macOS Virtual Machines][macos_instance]
 `freebsd_instance`         | **us**     | [FreeBSD Virtual Machines][freebsd_instance]
 `compute_engine_instance`  | **us**     | [Full-fledged custom VM][compute_engine_instance]


### PR DESCRIPTION
But it was a listed in list of such fields.
Fixes #1102 confusion.