### PR TITLE
fix: Bug causing option not found in flutter code example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -248,7 +248,7 @@ container:
 test_task:
   pub_cache:
     folder: ~/.pub-cache
-  test_script: flutter test -machine > report.json
+  test_script: flutter test --machine > report.json
   always:
     report_artifacts:
       path: report.json


### PR DESCRIPTION
Bad:
> flutter test -machine > report.json
Could not find an option with short name "-m".

Good:
> flutter test --machine > report.json