### PR TITLE
Document internals of OpenID Connect tokens

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -663,7 +663,7 @@ that can be used for assertions.
 }
 ```
 
-Please use the above claims to configure assertions in your external system. For example, you can asert that only tokens
+Please use the above claims to configure assertions in your external system. For example, you can assert that only tokens
 for specific branches can retrieve secrets for deploying to production.
 
 ## Encrypted Variables


### PR DESCRIPTION
For educational purposes since OICD is a pretty new standard.