### PR TITLE
Workload Identity Federation: add Service Account creation step

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -232,6 +232,7 @@ pre-configured
 pre-defined
 pre-install
 pre-installed
+pre-signed
 preemptible
 preinstalled.
 prepend

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -214,12 +214,7 @@ Now let's setup Cirrus CI as a workload identity provider:
     In the example above `--attribute-condition` flag asserts that the provider can be used with any repository of your organization.
     You can restrict the access further with attributes like `repository`, `repository_visibility` and `pr`.
 
-5. Create a Service Account that Cirrus CI will impersonate to manage compute resources:
-
-    ```sh
-    gcloud iam service-accounts create cirrus-ci \
-      --project="${PROJECT_ID}"
-    ```
+5. If not yet created, [create a Service Account](#google-cloud) that Cirrus CI will impersonate to manage compute resources and [assign it the required roles](#google-cloud).
 
 6. Allow authentications from the Workload Identity Provider originating from your organization to impersonate the Service Account created above:
 

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -214,8 +214,14 @@ Now let's setup Cirrus CI as a workload identity provider:
     In the example above `--attribute-condition` flag asserts that the provider can be used with any repository of your organization.
     You can restrict the access further with attributes like `repository`, `repository_visibility` and `pr`.
 
-5. Allow authentications from the Workload Identity Provider originating from 
-    your organization to impersonate the Service Account created above:
+5. Create a Service Account that Cirrus CI will impersonate to manage compute resources:
+
+    ```sh
+    gcloud iam service-accounts create cirrus-ci \
+    --project="${PROJECT_ID}"
+    ```
+
+6. Allow authentications from the Workload Identity Provider originating from your organization to impersonate the Service Account created above:
 
     ```sh
     gcloud iam service-accounts add-iam-policy-binding "cirrus-ci@${PROJECT_ID}.iam.gserviceaccount.com" \

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -99,7 +99,12 @@ assigned to the service account. But Cirrus CI will always need permissions to r
 ```bash
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member serviceAccount:cirrus-ci@$PROJECT_ID.iam.gserviceaccount.com \
-    --role roles/iam.serviceAccountTokenCreator \
+    --role roles/iam.serviceAccountTokenCreator
+```
+
+```bash
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member serviceAccount:cirrus-ci@$PROJECT_ID.iam.gserviceaccount.com \
     --role roles/monitoring.viewer
 ```
 

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -193,7 +193,7 @@ Now let's setup Cirrus CI as a workload identity provider:
     export WORKLOAD_IDENTITY_POOL_ID="..." # value from above
     ```
 
-4. Create a Workload Identity **Provider** in that pool:
+4. Create a Workload Identity Provider in that pool:
 
     ```sh
     # TODO(developer): Update this value to your GitHub organization.
@@ -230,7 +230,7 @@ Now let's setup Cirrus CI as a workload identity provider:
       --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_ID}/attribute.owner/${OWNER}"
     ```
 
-6. Extract the Workload Identity **Provider** resource name:
+7. Extract the Workload Identity Provider resource name:
 
     ```sh
     gcloud iam workload-identity-pools providers describe "cirrus-oidc" \

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -94,12 +94,12 @@ gcloud iam service-accounts create cirrus-ci \
 ```
 
 Depending on a compute service Cirrus CI will need different [roles](https://cloud.google.com/iam/docs/understanding-roles) 
-assigned to the service account. But Cirrus CI will always need permissions to act as a service account and be able to view monitoring:
+assigned to the service account. But Cirrus CI will always need permissions to refresh it's token, generate pre-signed URLs (for the artifacts upload/download to work) and be able to view monitoring:
 
 ```bash
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member serviceAccount:cirrus-ci@$PROJECT_ID.iam.gserviceaccount.com \
-    --role roles/iam.serviceAccountUser \
+    --role roles/iam.serviceAccountTokenCreator \
     --role roles/monitoring.viewer
 ```
 

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -218,7 +218,7 @@ Now let's setup Cirrus CI as a workload identity provider:
 
     ```sh
     gcloud iam service-accounts create cirrus-ci \
-    --project="${PROJECT_ID}"
+      --project="${PROJECT_ID}"
     ```
 
 6. Allow authentications from the Workload Identity Provider originating from your organization to impersonate the Service Account created above:


### PR DESCRIPTION
Otherwise when simply copying and pasting instructions the user will fail at step 6 (was step 5).