### PR TITLE
Drop prices even more

### DIFF
--- a/docs/blog/posts/2023-07-17-no-unlimited-free-usage.md
+++ b/docs/blog/posts/2023-07-17-no-unlimited-free-usage.md
@@ -13,8 +13,8 @@ categories:
 
 Unfortunately the day has come. As a self-bootstrapped company Cirrus Labs can no longer provide unlimited usage of Cirrus CI
 for public repositories for free. We have to put a limit on the amount of compute resources that can be consumed for free each month
-by organizations and users. Starting September 1st 2023, there will be an upper monthly limit on free usage equal to 40 compute credits
-(which is equal to 10,000 CPU-minutes for Linux tasks).
+by organizations and users. Starting September 1st 2023, there will be an upper monthly limit on free usage equal to 50 compute credits
+(which is equal to a little over 16,000 CPU-minutes for Linux tasks).
 
 The reason for the change is that we want to continue being a profitable business and keep Cirrus CI running,
 but unfortunately we haven’t found a better solution for a couple of ongoing issues described below.
@@ -36,8 +36,8 @@ Frequently we saw tasks requesting 8 CPUs and 24GB of memory, but in reality the
 # Silver lining
 
 In addition to introducing the limits we will also lower the prices for the existing compute resources. Starting August 1st,
-we are lowering [the existing pricing](https://cirrus-ci.org/pricing/#compute-credits) for macOS instances by 50% and
-by 20% for Linux, Windows and FreeBSD instances respectively.
+we are lowering [the existing pricing](https://cirrus-ci.org/pricing/#compute-credits) for macOS and Windows instances by 60% and
+by 40% for Linux and FreeBSD instances respectively.
 
 # How does this change affect me?
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -24,17 +24,14 @@ Sometimes configuring your own [compute services](#compute-services) isn't worth
 
 1 compute credit can be bought for 1 US dollar. Here is how much 1000 minutes of CPU time will cost for different platforms:
 
-* 1000 minutes of 1 virtual CPU for Linux platform for 4 compute credits
-* 1000 minutes of 1 virtual CPU for FreeBSD platform for 4 compute credits
-* 1000 minutes of 1 virtual CPU for Windows platform for 8 compute credits
-* 1000 minutes of 1 Apple Silicon CPU or 2 Intel virtual CPUs for macOS platform for 20 compute credits
+* 1000 minutes of 1 virtual CPU for Linux platform for 3 compute credits
+* 1000 minutes of 1 virtual CPU for FreeBSD platform for 3 compute credits
+* 1000 minutes of 1 virtual CPU for Windows platform for 4 compute credits
+* 1000 minutes of 1 Apple Silicon CPU for 15 compute credits
 
-All tasks using compute credits are charged on per-second basis. 2 CPU Linux task takes 2 minutes? Pay **2 cents**.
+All tasks using compute credits are charged on per-second basis. 2 CPU Linux task takes 5 minutes? Pay **3 cents**.
 
 **Note:** orchestration costs are included in compute credits and there is no need to purchase additional seats on your organization's plan.
-
-!!! info "Priority Scheduling"
-    Tasks that are using compute credits will be prioritized and will be scheduled as fast as possible.
 
 !!! tip "Works for OSS projects"
     Compute credits can be used for commercial OSS projects to avoid [concurrency limits](faq.md#are-there-any-limits).
@@ -44,7 +41,7 @@ All tasks using compute credits are charged on per-second basis. 2 CPU Linux tas
   
 * Use the same pre-configured infrastructure that we fine tune and constantly upgrade/improve.
 * No need to configure anything. Let Cirrus CI's team manage and upgrade infrastructure for you.
-* Per-second billing with no additional minimum or monthly fees.
+* Per-second billing with no additional monthly fees for storage and traffic.
 * Cost efficient for small to medium teams. 
   
 **Cons** of this approach:


### PR DESCRIPTION
After some additional calculations and projections we can pretty confidently drop prices even more. Here is a table that compares prices before August 1st and now:

| Platform | Old price before August 1st for 1,000 minutes | New price for 1,000 minutes | Drop in % 
| ------------- | ------------- | ------------- | ------------- |
| macOS  | 40  | 15 | 62.5%
| Windows  | 10  | 4 | 60%
| Linux | 5 | 3 | 40%
| FreeBSD | 5 | 3 | 40%
| Solaris | 5 | 3 | 40%
| NetBSD | 5 | 3 | 40%
