### PR TITLE
Update FreeBSD Examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,14 +2,14 @@
 hide:
   - navigation
 ---
-  
+
 # Examples
 
 Here you can find example configurations per different programming languages/frameworks.
 
 ## Android
 
-Cirrus CI has a [set of Docker images ready for Android development](https://github.com/cirruslabs/docker-images-android/pkgs/container/android-sdk). 
+Cirrus CI has a [set of Docker images ready for Android development](https://github.com/cirruslabs/docker-images-android/pkgs/container/android-sdk).
 If these images are not the right fit for your project you can always use any custom Docker image with Cirrus CI. For those
 images `.cirrus.yml` configuration file can look like:
 
@@ -55,7 +55,7 @@ check_android_task:
 
 !!! info
     Please don't forget to setup [Remote Build Cache](#build-cache) for your Gradle project.
-    
+
 ### Android Lint
 
 The Cirrus CI annotator supports providing inline reports on PRs and can parse Android Lint reports. Here is an example of an *Android Lint*
@@ -260,7 +260,7 @@ If these images are not the right fit for your project you can always use any cu
 ### Flutter Web
 
 [Our Docker images with Flutter and Dart SDK pre-installed](https://github.com/cirruslabs/docker-images-flutter/pkgs/container/flutter) have special `*-web` tags
-with [Chromium](https://www.chromium.org/) pre-installed. You can use these tags to run Flutter Web 
+with [Chromium](https://www.chromium.org/) pre-installed. You can use these tags to run Flutter Web
 
 First define a new `chromium` platform in your `dart_test.yaml`:
 
@@ -287,7 +287,7 @@ an example of how `.cirrus.yml` can look like for a project using Go Modules:
     ```yaml
     container:
       image: golang:latest
-    
+
     test_task:
       modules_cache:
         fingerprint_script: cat go.sum
@@ -302,7 +302,7 @@ an example of how `.cirrus.yml` can look like for a project using Go Modules:
     ```yaml
     arm_container:
       image: golang:latest
-    
+
     test_task:
       modules_cache:
         fingerprint_script: cat go.sum
@@ -350,7 +350,7 @@ task that you can add to your `.cirrus.yml`:
 
 ## Gradle
 
-We recommend use of the [official Gradle Docker containers](https://hub.docker.com/_/gradle/) since they have Gradle specific configurations already set up. For example, standard Java containers don't have 
+We recommend use of the [official Gradle Docker containers](https://hub.docker.com/_/gradle/) since they have Gradle specific configurations already set up. For example, standard Java containers don't have
 a pre-configured user and as a result don't have `HOME` environment variable presented which makes Gradle complain.
 
 ### Caching
@@ -364,7 +364,7 @@ files in `~/.gradle/caches` folder on every run which makes Cirrus CI re-upload 
     ```yaml
     container:
       image: gradle:jdk11
-    
+
     check_task:
       gradle_cache:
         folder: ~/.gradle/caches
@@ -382,7 +382,7 @@ files in `~/.gradle/caches` folder on every run which makes Cirrus CI re-upload 
     ```yaml
     arm_container:
       image: gradle:jdk11
-    
+
     check_task:
       gradle_cache:
         folder: ~/.gradle/caches
@@ -492,7 +492,7 @@ Official [Maven Docker images](https://hub.docker.com/_/maven/) can be used for 
 ## MySQL
 
 The [Additional Containers feature](guide/writing-tasks.md#additional-containers) makes it super simple to run the same Docker
-MySQL image as you might be running in production for your application. Getting a running instance of the latest GA 
+MySQL image as you might be running in production for your application. Getting a running instance of the latest GA
 version of MySQL can used with the following six lines in your `.cirrus.yml`:
 
 === "amd64"
@@ -523,7 +523,7 @@ version of MySQL can used with the following six lines in your `.cirrus.yml`:
             MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ```
 
-With the configuration above MySQL will be available on `localhost:3306`. Use empty password to login as `root` user. 
+With the configuration above MySQL will be available on `localhost:3306`. Use empty password to login as `root` user.
 
 ## Node
 
@@ -538,7 +538,7 @@ Here is an example of a `.cirrus.yml` that caches `node_modules` based on conten
     ```yaml
     container:
       image: node:latest
-    
+
     test_task:
       node_modules_cache:
         folder: node_modules
@@ -552,7 +552,7 @@ Here is an example of a `.cirrus.yml` that caches `node_modules` based on conten
     ```yaml
     arm_container:
       image: node:latest
-    
+
     test_task:
       node_modules_cache:
         folder: node_modules
@@ -570,7 +570,7 @@ Here is an example of a `.cirrus.yml` that caches `node_modules` based on the co
     ```yaml
     container:
       image: node:latest
-    
+
     test_task:
       node_modules_cache:
         folder: node_modules
@@ -584,7 +584,7 @@ Here is an example of a `.cirrus.yml` that caches `node_modules` based on the co
     ```yaml
     arm_container:
       image: node:latest
-    
+
     test_task:
       node_modules_cache:
         folder: node_modules
@@ -682,7 +682,7 @@ Here is an example of how  `*.proto` files can be linted using [Buf CLI](https:/
 
 ## Python
 
-Official [Python Docker images](https://hub.docker.com/_/python/) can be used for builds. Here is an example of a `.cirrus.yml` 
+Official [Python Docker images](https://hub.docker.com/_/python/) can be used for builds. Here is an example of a `.cirrus.yml`
 that caches installed packages based on contents of `requirements.txt` and runs `pytest`:
 
 === "amd64"
@@ -690,7 +690,7 @@ that caches installed packages based on contents of `requirements.txt` and runs 
     ```yaml
     container:
       image: python:slim
-    
+
     test_task:
       pip_cache:
         folder: ~/.cache/pip
@@ -704,7 +704,7 @@ that caches installed packages based on contents of `requirements.txt` and runs 
     ```yaml
     arm_container:
       image: python:slim
-    
+
     test_task:
       pip_cache:
         folder: ~/.cache/pip
@@ -713,7 +713,7 @@ that caches installed packages based on contents of `requirements.txt` and runs 
       test_script: pytest
     ```
 
-### Building PyPI Packages  
+### Building PyPI Packages
 
 Also using the Python Docker images, you can run tests if you are making packages for [PyPI](https://pypi.org). Here is an example `.cirrus.yml` for doing so:
 
@@ -722,7 +722,7 @@ Also using the Python Docker images, you can run tests if you are making package
     ```yaml
     container:
       image: python:slim
-    
+
     build_package_test_task:
       pip_cache:
         folder: ~/.cache/pip
@@ -736,7 +736,7 @@ Also using the Python Docker images, you can run tests if you are making package
     ```yaml
     arm_container:
       image: python:slim
-    
+
     build_package_test_task:
       pip_cache:
         folder: ~/.cache/pip
@@ -839,12 +839,12 @@ task:
 ## Release Assets
 
 Cirrus CI doesn't provide a built-in functionality to upload artifacts on a GitHub release but this functionality can be
-added via a script. For a release, Cirrus CI will provide `CIRRUS_RELEASE` environment variable along with `CIRRUS_TAG` 
+added via a script. For a release, Cirrus CI will provide `CIRRUS_RELEASE` environment variable along with `CIRRUS_TAG`
 environment variable. `CIRRUS_RELEASE` indicates release id which can be used to upload assets.
 
-Cirrus CI only requires write access to Check API and doesn't require write access to repository contents because of security 
+Cirrus CI only requires write access to Check API and doesn't require write access to repository contents because of security
 reasons. That's why you need to [create a personal access token](https://github.com/settings/tokens/new) with full access
-to `repo` scope. Once an access token is created, please [create an encrypted variable](guide/writing-tasks.md#encrypted-variables) 
+to `repo` scope. Once an access token is created, please [create an encrypted variable](guide/writing-tasks.md#encrypted-variables)
 from it and save it to `.cirrus.yml`:
 
 ```yaml
@@ -896,7 +896,7 @@ contents of `Gemfile.lock`, and runs `rspec`:
     ```yaml
     container:
       image: ruby:latest
-    
+
     rspec_task:
       bundle_cache:
         folder: /usr/local/bundle
@@ -917,7 +917,7 @@ contents of `Gemfile.lock`, and runs `rspec`:
     ```yaml
     arm_container:
       image: ruby:latest
-    
+
     rspec_task:
       bundle_cache:
         folder: /usr/local/bundle
@@ -941,11 +941,11 @@ contents of `Gemfile.lock`, and runs `rspec`:
     Here is an example of a `.cirrus.yml` that always runs `bundle install`:
 
     === "amd64"
-    
+
         ```yaml
         container:
           image: ruby:latest
-        
+
         rspec_task:
           bundle_cache:
             folder: /usr/local/bundle
@@ -958,11 +958,11 @@ contents of `Gemfile.lock`, and runs `rspec`:
         ```
 
     === "arm64"
-    
+
         ```yaml
         arm_container:
           image: ruby:latest
-        
+
         rspec_task:
           bundle_cache:
             folder: /usr/local/bundle
@@ -977,7 +977,7 @@ contents of `Gemfile.lock`, and runs `rspec`:
 !!! tip "Test Parallelization"
     It's super easy to add intelligent test splitting by using [Knapsack Pro](https://knapsackpro.com/) and [matrix modification](guide/writing-tasks.md#matrix-modification).
     After [setting up Knapsack Pro gem](https://docs.knapsackpro.com/knapsack_pro-ruby/guide/), you can add sharding like this:
-    
+
     ```yaml
     task:
       matrix:
@@ -991,8 +991,8 @@ contents of `Gemfile.lock`, and runs `rspec`:
         populate_script: bundle install
       rspec_script: bundle exec rake knapsack_pro:rspec
     ```
-    
-    Which will create four shards that will theoretically **run tests 4x faster** by equally splitting all tests between 
+
+    Which will create four shards that will theoretically **run tests 4x faster** by equally splitting all tests between
     these four shards.
 
 ### RSpec and RuboCop Annotations
@@ -1006,7 +1006,7 @@ To get behavior-driven test annotations, generate and upload a `rspec` artifact 
     ```yaml
     container:
       image: ruby:latest
-    
+
     task:
       name: RSpec
       bundle_cache:
@@ -1028,7 +1028,7 @@ To get behavior-driven test annotations, generate and upload a `rspec` artifact 
     ```yaml
     arm_container:
       image: ruby:latest
-    
+
     task:
       name: RSpec
       bundle_cache:
@@ -1052,7 +1052,7 @@ Generate a `rubocop` artifact to quickly gain context for linter/formatter annot
     ```yaml
     container:
       image: ruby:latest
-    
+
     task:
       name: RuboCop
       bundle_cache:
@@ -1074,7 +1074,7 @@ Generate a `rubocop` artifact to quickly gain context for linter/formatter annot
     ```yaml
     arm_container:
       image: ruby:latest
-    
+
     task:
       name: RuboCop
       bundle_cache:
@@ -1093,7 +1093,7 @@ Generate a `rubocop` artifact to quickly gain context for linter/formatter annot
 
 ## Rust
 
-Official [Rust Docker images](https://hub.docker.com/_/rust/) can be used for builds. Here is a basic example of `.cirrus.yml` 
+Official [Rust Docker images](https://hub.docker.com/_/rust/) can be used for builds. Here is a basic example of `.cirrus.yml`
 that caches crates in `$CARGO_HOME` based on contents of `Cargo.lock`:
 
 === "amd64"
@@ -1101,7 +1101,7 @@ that caches crates in `$CARGO_HOME` based on contents of `Cargo.lock`:
     ```yaml
     container:
       image: rust:latest
-    
+
     test_task:
       registry_cache:
         folder: $CARGO_HOME/registry
@@ -1121,7 +1121,7 @@ that caches crates in `$CARGO_HOME` based on contents of `Cargo.lock`:
     ```yaml
     arm_container:
       image: rust:latest
-    
+
     test_task:
       registry_cache:
         folder: $CARGO_HOME/registry
@@ -1138,13 +1138,13 @@ that caches crates in `$CARGO_HOME` based on contents of `Cargo.lock`:
 
 !!! tip "Caching Cleanup"
 
-    Please note `before_cache_script` that removes registry index from the cache before uploading it in the end of a successful task. 
+    Please note `before_cache_script` that removes registry index from the cache before uploading it in the end of a successful task.
     Registry index is [changing very rapidly](https://github.com/rust-lang/crates.io-index) making the cache invalid. `before_cache_script`
     deletes the index and leaves only the required crates for caching.
 
 ### Rust Nightly
 
-It is possible to use nightly builds of Rust via an [official `rustlang/rust:nightly` container](https://hub.docker.com/r/rustlang/rust/). 
+It is possible to use nightly builds of Rust via an [official `rustlang/rust:nightly` container](https://hub.docker.com/r/rustlang/rust/).
 Here is an example of a `.cirrus.yml` to run tests against the latest stable and nightly versions of Rust:
 
 === "amd64"
@@ -1200,8 +1200,8 @@ Here is an example of a `.cirrus.yml` to run tests against the latest stable and
 
     ```yaml
     freebsd_instance:
-      image-family: freebsd-12-0
-    
+      image-family: freebsd-14-0
+
     task:
       name: cargo test (stable)
       env:

--- a/docs/guide/FreeBSD.md
+++ b/docs/guide/FreeBSD.md
@@ -1,6 +1,6 @@
 ## FreeBSD Virtual Machines
 
-It is possible to run FreeBSD Virtual Machines the same way one can run [Linux containers](linux.md) on the FreeBSD Cloud Cluster. 
+It is possible to run FreeBSD Virtual Machines the same way one can run [Linux containers](linux.md) on the FreeBSD Cloud Cluster.
 To accomplish this, use `freebsd_instance` in your `.cirrus.yml`:
 
 ```yaml
@@ -13,13 +13,13 @@ task:
 ```
 
 !!! info "Under the Hood"
-    Under the hood, a basic integration with [Google Compute Engine](supported-computing-services.md#compute-engine) 
+    Under the hood, a basic integration with [Google Compute Engine](supported-computing-services.md#compute-engine)
     is used and `freebsd_instance` is a syntactic sugar for the following [`compute_engine_instance`](custom-vms.md) configuration:
 
     ```yaml
     compute_engine_instance:
       image_project: freebsd-org-cloud-dev
-      image: family/freebsd-13-0
+      image: family/freebsd-14-0
       platform: freebsd
     ```
 
@@ -30,15 +30,6 @@ Any of the official FreeBSD VMs on Google Cloud Platform are supported. Here are
 * `freebsd-15-0-snap` (15.0-SNAP)
 * `freebsd-14-0`      (14.0-RELEASE)
 * `freebsd-13-2`      (13.2-RELEASE)
-* `freebsd-13-1`      (13.1-RELEASE)
-* `freebsd-13-0`      (13.0-RELEASE)
-* `freebsd-12-4`      (12.4-RELEASE)
-* `freebsd-12-3`      (12.3-RELEASE)
-* `freebsd-12-2`      (12.2-RELEASE)
-* `freebsd-12-0`      (12.0-RELEASE)
-* `freebsd-11-4`      (11.4-RELEASE)
-* `freebsd-11-3-snap` (11.3-STABLE)
-* `freebsd-11-3`      (11.3-RELEASE, doesn't boot properly at the moment)
 
 It's also possible to specify a concrete version of an image by name via `image_name` field. To get a full list of
 available images please run the following [gcloud](https://cloud.google.com/sdk/gcloud/) command:

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -50,7 +50,7 @@ Using a new VM or a new Docker Container each time for running tasks has many be
   VM image version and Docker Container image version. After committing changes to `.cirrus.yml` not only new tasks will use the new environment,
   but also outdated branches will continue using the old configuration.
 * **Reproducibility.** Fresh environment guarantees no corrupted artifacts or caches are presented from the previous tasks.
-* **Cost efficiency.** Most compute services are offering per-second pricing which makes them ideal for using with Cirrus CI. 
+* **Cost efficiency.** Most compute services are offering per-second pricing which makes them ideal for using with Cirrus CI.
   Also each task for repository can define ideal amount of CPUs and Memory specific for a nature of the task. No need to manage
   pools of similar VMs or try to fit workloads within limits of a given Continuous Integration systems.
 
@@ -61,8 +61,8 @@ To be fair there are of course some disadvantages of starting a new VM or a cont
   on average for starting up VMs is not a big inconvenience in favor of more stable, reliable and more reproducible CI.
 * **Cold local caches for every task execution.** Many tools tend to store some caches like downloaded dependencies locally
   to avoid downloading them again in future. Since Cirrus CI always uses fresh VMs and containers such local caches will always
-  be empty. Performance implication of empty local caches can be avoided by using Cirrus CI features like 
-  [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can 
+  be empty. Performance implication of empty local caches can be avoided by using Cirrus CI features like
+  [built-in caching mechanism](writing-tasks.md#cache-instruction). Some tools like [Gradle](https://gradle.org/) can
   even take advantages of [built-in HTTP cache](writing-tasks.md#http-cache)!
 
 Please check the list of currently supported cloud compute services below. In case you have your own hardware, please
@@ -77,23 +77,23 @@ take a look at [Persistent Workers](persistent-workers.md), which allow connecti
   </a>
 </p>
 
-Cirrus CI can schedule tasks on several Google Cloud Compute services. In order to interact with Google Cloud APIs 
-Cirrus CI needs permissions. Creating a [service account](https://cloud.google.com/compute/docs/access/service-accounts) 
-is a common way to safely give granular access to parts of Google Cloud Projects. 
+Cirrus CI can schedule tasks on several Google Cloud Compute services. In order to interact with Google Cloud APIs
+Cirrus CI needs permissions. Creating a [service account](https://cloud.google.com/compute/docs/access/service-accounts)
+is a common way to safely give granular access to parts of Google Cloud Projects.
 
 !!! warning "Isolation"
     We do recommend to create a separate Google Cloud project for running CI builds to make sure tests are
     isolated from production data. Having a separate project also will show how much money is spent on CI and how
     efficient Cirrus CI is :wink:
 
-Once you have a Google Cloud project for Cirrus CI please create a service account by running the following command: 
+Once you have a Google Cloud project for Cirrus CI please create a service account by running the following command:
 
 ```bash
 gcloud iam service-accounts create cirrus-ci \
     --project $PROJECT_ID
 ```
 
-Depending on a compute service Cirrus CI will need different [roles](https://cloud.google.com/iam/docs/understanding-roles) 
+Depending on a compute service Cirrus CI will need different [roles](https://cloud.google.com/iam/docs/understanding-roles)
 assigned to the service account. But Cirrus CI will always need permissions to refresh it's token, generate pre-signed URLs (for the artifacts upload/download to work) and be able to view monitoring:
 
 ```bash
@@ -191,7 +191,7 @@ Now let's setup Cirrus CI as a workload identity provider:
       --location="global" \
       --format="value(name)"
     ```
-   
+
     Save this value as an environment variable:
 
     ```sh
@@ -203,7 +203,7 @@ Now let's setup Cirrus CI as a workload identity provider:
     ```sh
     # TODO(developer): Update this value to your GitHub organization.
     export OWNER="organization" # e.g. "cirruslabs"
-   
+
     gcloud iam workload-identity-pools providers create-oidc "cirrus-oidc" \
       --project="${PROJECT_ID}" \
       --location="global" \
@@ -266,7 +266,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
     --role roles/compute.admin
 ```
 
-Now tasks can be scheduled on Compute Engine within `$PROJECT_ID` project by configuring `gce_instance` something 
+Now tasks can be scheduled on Compute Engine within `$PROJECT_ID` project by configuring `gce_instance` something
 like this:
 
 ```yaml
@@ -279,7 +279,7 @@ gce_instance:
   memory: 40GB
   disk: 60
   use_ssd: true # default to false
-  
+
 task:
   script: ./run-ci.sh
 ```
@@ -287,7 +287,7 @@ task:
 !!! tip "Specify Machine Type"
     It is possible to specify a [predefined machine type](https://cloud.google.com/compute/docs/machine-types) via `type`
     field:
-    
+
     ```yaml
     gce_instance:
       image_project: ubuntu-os-cloud
@@ -332,7 +332,7 @@ gce_instance:
   cpu: 8
   memory: 40GB
   disk: 20
-  
+
 task:
   script: run-ci.bat
 ```
@@ -345,13 +345,13 @@ platform of an image like this:
 ```yaml
 gce_instance:
   image_project: freebsd-org-cloud-dev
-  image_family: freebsd-12-1
+  image_family: freebsd-14-0
   platform: FreeBSD
   zone: us-central1-a
   cpu: 8
   memory: 40GB
   disk: 50
-  
+
 task:
   script: printenv
 ```
@@ -392,9 +392,9 @@ gce_container:
 
 #### Instance Scopes
 
-By default Cirrus CI will create Google Compute instances without any [scopes](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes) 
-so an instance can't access Google Cloud Storage for example. But sometimes it can be useful to give some permissions to an 
-instance by using `scopes` key of `gce_instance`.  For example, if a particular task builds Docker images and then pushes 
+By default Cirrus CI will create Google Compute instances without any [scopes](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes)
+so an instance can't access Google Cloud Storage for example. But sometimes it can be useful to give some permissions to an
+instance by using `scopes` key of `gce_instance`.  For example, if a particular task builds Docker images and then pushes
 them to [Container Registry](https://cloud.google.com/container-registry/), its configuration file can look something like:
 
 ```yaml
@@ -422,7 +422,7 @@ push_docker_task:
 #### Spot Instances
 
 Cirrus CI can schedule [spot](https://cloud.google.com/compute/docs/instances/spot) instances with all price
-benefits and stability risks. But sometimes risks of an instance being preempted at any time can be tolerated. For example 
+benefits and stability risks. But sometimes risks of an instance being preempted at any time can be tolerated. For example
 `gce_instance` can be configured to schedule spot instance for non master branches like this:
 
 ```yaml
@@ -478,7 +478,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
     --role roles/container.admin
 ```
 
-Done! Now after creating `cirrus-ci-cluster` cluster and having `gcp_credentials` configured tasks can be scheduled on the 
+Done! Now after creating `cirrus-ci-cluster` cluster and having `gcp_credentials` configured tasks can be scheduled on the
 newly created cluster like this:
 
 ```yaml
@@ -500,17 +500,17 @@ gke_container:
 ```
 
 !!! tip "Using in-memory disk"
-    By default Cirrus CI mounts an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) into 
-    `/tmp` path to protect the pod from unnecessary eviction by autoscaler. It is possible to switch emptyDir's medium to 
+    By default Cirrus CI mounts an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) into
+    `/tmp` path to protect the pod from unnecessary eviction by autoscaler. It is possible to switch emptyDir's medium to
     use in-memory `tmpfs` storage instead of a default one by setting `use_in_memory_disk` field of `gke_container` to `true`
     or any other expression that uses environment variables.
 
 !!! tip "Running privileged containers"
-    You can run privileged containers on your private GKE cluster by setting `privileged` field of `gke_container` to `true` 
+    You can run privileged containers on your private GKE cluster by setting `privileged` field of `gke_container` to `true`
     or any other expression that uses environment variables. `privileged` field is also available for any additional container.
-    
+
     Here is an example of how to run docker-in-docker
-    
+
     ```yaml hl_lines="9"
     gke_container:
       image: my-docker-client:latest
@@ -562,7 +562,7 @@ via a more flexible and secure [Identity Provider](#cirrus-as-an-openid-connect-
     ]
     ```
 
-#### IAM user credentials 
+#### IAM user credentials
 
 Creating an [IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) for programmatic access
 is a common way to safely give granular access to parts of your AWS.
@@ -581,11 +581,11 @@ Then you'll be able to use the encrypted variable in your `.cirrus.yml` file lik
 ```yaml
 aws_credentials: ENCRYPTED[...]
 
-task:  
+task:
   ec2_instance:
     ...
-    
-task:  
+
+task:
   eks_container:
     ...
 ```
@@ -695,7 +695,7 @@ In order to schedule tasks on EC2 please make sure that IAM user or OIDC role th
 
 Now tasks can be scheduled on EC2 by configuring `ec2_instance` something like this:
 
-```yaml  
+```yaml
 task:
   ec2_instance:
     image: ami-0a047931e1d42fdb3
@@ -703,7 +703,7 @@ task:
     region: us-east-1
     subnet_ids: # optional, list of subnets from your default VPC to randomly choose from for scheduling the instance
       - ...
-    subnet_filters: # optional, map of filters to use for DescribeSubnets API call. Note to make sure Cirrus is given `ec2:DescribeSubnets`  
+    subnet_filters: # optional, map of filters to use for DescribeSubnets API call. Note to make sure Cirrus is given `ec2:DescribeSubnets`
       - name: tag:Name
         values:
           - subnet1
@@ -718,7 +718,7 @@ task:
         virtual_name: ephemeral0 # to add an ephemeral disk for supported instances
       - device_name: /dev/sdj
         ebs:
-          snapshot_id: snap-xxxxxxxx 
+          snapshot_id: snap-xxxxxxxx
   script: ./run-ci.sh
 ```
 
@@ -808,7 +808,7 @@ $: kubectl get nodes
     If you have an issue with accessing your EKS cluster via `kubectl`, most likely you did **not** create the cluster
     with the user that Cirrus CI is using. The easiest way to do so is to create the cluster through AWS CLI with the
     following command:
-    
+
     ```bash
     $: aws sts get-caller-identity
     {
@@ -820,11 +820,11 @@ $: kubectl get nodes
         create-cluster --name cirrus-ci \
         --role-arn ... \
         --resources-vpc-config subnetIds=...,securityGroupIds=...
-    ```   
+    ```
 
 Now tasks can be scheduled on EKS by configuring `eks_container` something like this:
 
-```yaml  
+```yaml
 task:
   eks_container:
     image: node:latest
@@ -855,12 +855,12 @@ task:
   </a>
 </p>
 
-Cirrus CI can schedule tasks on several Azure services. In order to interact with Azure APIs 
+Cirrus CI can schedule tasks on several Azure services. In order to interact with Azure APIs
 Cirrus CI needs permissions. First, please choose a subscription you want to use for scheduling CI tasks.
 [Navigate to the Subscriptions blade within the Azure Portal](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade)
 and save `$SUBSCRIPTION_ID` that we'll use below for setting up a service principle.
 
-Creating a [service principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli) 
+Creating a [service principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli)
 is a common way to safely give granular access to parts of Azure:
 
 ```bash
@@ -882,7 +882,7 @@ Command above will create a new service principal and will print something like:
 
 Please also remember `clientId` from the JSON as `$CIRRUS_CLIENT_ID`. It will be used later for configuring blob storage access.
 
-Please create an [encrypted variable](writing-tasks.md#encrypted-variables) from this output and 
+Please create an [encrypted variable](writing-tasks.md#encrypted-variables) from this output and
 add it to the top of `.cirrus.yml` file:
 
 ```yaml
@@ -914,8 +914,8 @@ Now Cirrus CI can interact with Azure APIs.
   </a>
 </p>
 
-[Azure Container Instances (ACI)](https://azure.microsoft.com/en-us/services/container-instances/) is an ideal 
-candidate for running modern CI workloads. ACI allows *just* to run Linux and Windows containers without thinking about 
+[Azure Container Instances (ACI)](https://azure.microsoft.com/en-us/services/container-instances/) is an ideal
+candidate for running modern CI workloads. ACI allows *just* to run Linux and Windows containers without thinking about
 underlying infrastructure.
 
 Once `azure_credentials` is configured as described above, tasks can be scheduled on ACI by configuring `aci_instance` like this:
@@ -1003,7 +1003,7 @@ oracle_credentials: ENCRYPTED[qwerty239abc]
 Please create a Kubernetes cluster and make sure *Kubernetes API Public Endpoint* is enabled for the cluster so Cirrus
 can access it. Then copy cluster id which can be used in configuring `oke_container`:
 
-```yaml  
+```yaml
 task:
   oke_container:
     cluster_id: ocid1.cluster.oc1.iad.xxxxxx


### PR DESCRIPTION
- Maintain consistency on FreeBSD versions across all documents
- There are couple of images listed which have long reached EOL in the FreeBSD world. Using the images are discouraged as none of those images can install additional third party pkgs any more and eventually failing the CI pipelines. These example has been removed.