### PR TITLE
[blog] StandBy Instances

### DIFF
--- a/docs/blog/posts/2024-03-29-standby-instance.md
+++ b/docs/blog/posts/2024-03-29-standby-instance.md
@@ -1,0 +1,66 @@
+---
+draft: false
+date: 2024-03-29
+search:
+  exclude: true
+authors:
+  - fkorotkov
+categories:
+  - announcement
+---
+
+## Cirrus CI Persistent Workers Get a Boost with Standby Instances
+
+We're excited to announce a new feature for Cirrus CI persistent workers: **Standby Instances**. This functionality significantly improves scheduling efficiency when dealing with many persistent workers, leading to faster task execution and a smoother CI/CD experience.
+
+### Background: Persistent Workers and Scheduling Challenges
+
+Cirrus CI's persistent workers offer a powerful way to run tasks on dedicated infrastructure, including bare metal and virtual machines. This is ideal for scenarios where you need more control over the environment or want to leverage specific hardware configurations.
+
+However, with many persistent workers, scheduling tasks efficiently can be challenging. Previously, when a task was assigned to a worker, **the persistent worker itself would**:
+
+1. **Pull an image:** This could take several minutes if the image is missing or outdated.
+2. **Boot the VM:** This added another 10-20 seconds to the overall task execution time.
+
+This delay could be frustrating, especially when dealing with frequent builds and deployments.
+
+### Introducing Standby Instances: Faster Scheduling, Smoother CI/CD
+
+Standby instances address this challenge by ensuring tasks are assigned to workers that are already prepared. Here's how it works:
+
+* You can now define a **standby configuration** for your persistent workers. This configuration specifies the desired VM image (e.g., a specific macOS version via Tart) and resource requirements (CPU, memory, etc.).
+* **Each persistent worker will proactively start and maintain a single standby instance** based on your configuration. This instance is ready to execute tasks immediately, eliminating the image pull and worker startup delays.
+* When a task is ready, **the persistent worker itself checks if its standby instance matches the task's isolation and resource requirements**. If it does, the task is executed immediately on the standby instance.
+* If the standby instance doesn't match the task's requirements, **the persistent worker will create a new instance** as usual.
+
+**Note:** Cirrus CI itself does not have knowledge of standby instances on persistent workers. The efficiency improvement happens directly on the worker level when there is a match between the task's isolation configuration and the standby instance's isolation.
+
+This new approach offers several benefits:
+
+* **Faster task execution:** By eliminating the initial image pull and worker startup time, tasks can start running immediately, leading to faster feedback and quicker deployments.
+* **Smoother CI/CD experience:** With faster and more predictable task execution, your CI/CD pipelines will run more smoothly, reducing bottlenecks and wait times.
+
+**Note:** While standby instances do not directly improve resource utilization, they ensure that resources are used effectively by minimizing the time spent on image pulls and worker startup. This leads to a more efficient CI/CD process overall.
+
+### Example Standby Configuration
+
+Here's an example of how to configure a standby instance for a persistent worker using Tart:
+
+```yaml
+standby:
+  resources:
+    tart-vms: 1
+  isolation:
+    tart:
+      image: ghcr.io/cirruslabs/macos-sonoma-base:latest
+      user: admin
+      password: admin
+      cpu: 4
+      memory: 12
+```
+
+This configuration ensures that the persistent worker will keep one macOS Sonoma VM running and ready to execute tasks that require this specific environment and resources.
+
+### Conclusion
+
+Standby instances are a powerful way to improve the performance and efficiency of your Cirrus CI persistent workers. We encourage you to try it out and experience the benefits for yourself. If you have any questions or need assistance with configuration, please don't hesitate to reach out to our support team at [support@cirruslabs.org](mailto:support@cirruslabs.org).


### PR DESCRIPTION
This blog post is generated via Gemini 1.5 Pro. I uploaded Cirrus CLI repository and asked the following prompt:

```
You are a marketing specialist at Cirrus Labs startup that develops Cirrus CI -- continuous integration system as a service. Recently engineers added a new functionality called "Stand By Instance" for Cirrus CI's persistent workers. You are tasked to write an announcement blog post about this feature describing how instances are started regularly and how  standby instances can improve scheduling when there are many persistent workers. In a nutshell before a task could've been scheduled to a worker that needed to pull a new image which can take several minutes, then start it which takes another 10-20 seconds. With standby instance we make sure that tasks are assigned to workers which already did the preparation.

Please check out sources of Cirrus CLI where Persistent Worker functionality is implemented:

cirrus-cli (215 files, 105,482 Tokens)

Once you get familiarized with the source code and concepts please ask any questions that you are not sure about. Then write the blog post in Markdown since we use Material for MkDocs for our website.

PS Tart and Vetu virtualizations are product of Cirrus Labs and there will be an opportunity please plug mentions of it. You'll get extra bonus based on performance of the blog post.
```