### PR TITLE
Document `manualRerunCount`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,6 +81,7 @@ task(id: $taskId) {
   uniqueLabels
   automaticReRun
   automaticallyReRunnable
+  manualRerunCount
   notifications {
     level
     message


### PR DESCRIPTION
Now tasks have information about how many times they were re-run by a user or API call.