### PR TITLE
Document image owners for EC2 instances

### DIFF
--- a/docs/guide/docker-builder-vm.md
+++ b/docs/guide/docker-builder-vm.md
@@ -215,6 +215,8 @@ You will see such `build_docker_image_HASH` tasks in the UI.
       cluster_name: my-company-arm-cluster
       dockerfile: .ci/Dockerfile
       builder_image: MY_DOCKER_AMI
+      builder_image_owners: # optional, defaults to self, amazon and aws-marketplace
+        - self
       builder_role: cirrus-builder # role for builder instance profile
       builder_instance_type: c7g.xlarge # should match the architecture below
       builder_subnet_ids: # optional, list of subnets from your default VPC to randomly choose from for scheduling the instance

--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -753,6 +753,8 @@ to figure out the ami right before scheduling the instance. Please make use AMI 
 ec2_task:
   ec2_instance:
     image: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*
+    image_owners: # optional, defaults to self, amazon and aws-marketplace
+      - aws-marketplace
     architecture: arm64
     region: us-east-2
     type: a1.metal


### PR DESCRIPTION
Cirrus CI now passes an owner list that can be either account IDs or aliases when it tried to resolve a filter