### PR TITLE
Update required EKS permissions

### DIFF
--- a/docs/guide/supported-computing-services.md
+++ b/docs/guide/supported-computing-services.md
@@ -786,9 +786,6 @@ add necessary permissions for the IAM user or OIDC role that Cirrus CI is using:
 "Action": [
   "iam:PassRole",
   "eks:DescribeCluster",
-  "eks:CreateCluster",
-  "eks:DeleteCluster",
-  "eks:UpdateClusterVersion",
   "ecr:DescribeImages",
 ]
 ```


### PR DESCRIPTION
We only call [`DescribeCluster` API method](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html) to get credentials for `kubectl`.