### PR TITLE
Fix doc/* to doc/**

### DIFF
--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -1140,7 +1140,7 @@ lint_task:
 
 ```yaml
 build_task:
-  skip: "changesIncludeOnly('doc/*')"
+  skip: "changesIncludeOnly('doc/**')"
 ```
 
 ## Auto-Cancellation of Tasks


### PR DESCRIPTION
Seems reasonable and more expected to document the recursive matching by default.