### PR TITLE
docs: correct spelling

### DIFF
--- a/docs/blog/posts/2022-11-08-sunsetting-intel-macos-instances.md
+++ b/docs/blog/posts/2022-11-08-sunsetting-intel-macos-instances.md
@@ -40,7 +40,7 @@ We had to implement some extra Ansible magic that distributed these templates vi
 The magic pulled a new template from Anka registry to a single host, then the next two hosts instead of pulling from the registry, used `scp` to copy
 from the previous hosts, etc. That unblocked our growth and we continued using Anka.
 
-Then in the end of 2019 - early 2020 there were a bunch of transient issues with Anka's networking layer. Sometimes some hosts were just loosing
+Then in the end of 2019 - early 2020 there were a bunch of transient issues with Anka's networking layer. Sometimes some hosts were just losing
 internet connections and all consecutive Anka VMs were not able to run anything until a restart of a host. We spent countless hours with Veertu folks
 trying to debug this transient but very annoying issue with no luck. In the end we had to implement some workaround and detections on our end.
 At this point we started thinking of a way to replace Anka Controller, so we could potentially switch the virtualization layer as well.

--- a/docs/guide/docker-builder-vm.md
+++ b/docs/guide/docker-builder-vm.md
@@ -195,7 +195,7 @@ You will see such `build_docker_image_HASH` tasks in the UI.
       namespace: default
     ```
 
-    Please make sure your buidler image has [`gcloud` configured as a credential helper](https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker).
+    Please make sure your builder image has [`gcloud` configured as a credential helper](https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker).
     
     If your builder image is stored in another project you can also specify it by using `builder_image_project` field.
     By default, Cirrus CI assumes builder image is stored within the same project as the GKE cluster.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -99,7 +99,7 @@ After clicking on `Sign In` you'll be redirected to GitHub in order to authorize
     These permissions are read-only except for write access to checks and commit statuses in order for Cirrus CI to
     be able to report task statuses via checks or commit statuses.
 
-    There is a long thread disscussing this weird "*Act on your behalf*" wording [here](https://github.community/t/why-does-this-forum-need-permission-to-act-on-my-behalf/120453/7)
+    There is a long thread discussing this weird "*Act on your behalf*" wording [here](https://github.community/t/why-does-this-forum-need-permission-to-act-on-my-behalf/120453/7)
     on GitHub's own commuity forum.
 
 ## Enabling New Repositories after Installation

--- a/docs/guide/writing-tasks.md
+++ b/docs/guide/writing-tasks.md
@@ -1431,7 +1431,7 @@ https://api.cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>.svg?task=bu
 
 ### Badges in Markdown
 
-Here is how Cirrus CI's badge can be embeded in a Markdown file:
+Here is how Cirrus CI's badge can be embedded in a Markdown file:
 
 ```markdown
 [![Build Status](https://api.cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>.svg)](https://cirrus-ci.com/github/<USER OR ORGANIZATION>/<REPOSITORY>)


### PR DESCRIPTION
This pull request makes several minor corrections to documentation files, primarily fixing typos and improving clarity. No functional or technical changes are included.

Documentation typo fixes:

* Corrected "loosing" to "losing" in the Anka networking discussion in `2022-11-08-sunsetting-intel-macos-instances.md`.
* Fixed "buidler" to "builder" in the Docker builder guide in `docker-builder-vm.md`.
* Corrected "disscussing" to "discussing" and "commuity" to "community" in the quick start guide in `quick-start.md`.
* Changed "embeded" to "embedded" in the writing tasks guide in `writing-tasks.md`.